### PR TITLE
Parameterize API_PORT end-to-end

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,11 +15,11 @@ services:
       DEEPINFRA_API_KEY: ${DEEPINFRA_API_KEY:-}
       AGENT_VERBOSE: ${AGENT_VERBOSE:-false}
     ports:
-      - "${API_PORT:-8000}:8000"
+      - "${API_PORT:-8000}:${API_PORT:-8000}"
     volumes:
       - .:/app
     command: >
-      sh -c "alembic upgrade head && uvicorn braindb.main:app --host 0.0.0.0 --port 8000 --reload"
+      sh -c "alembic upgrade head && uvicorn braindb.main:app --host 0.0.0.0 --port ${API_PORT:-8000} --reload"
 
   watcher:
     build: .


### PR DESCRIPTION
Follows up #1. Replaces the remaining two hardcoded references to `8000` in `docker-compose.yml` so `API_PORT` is honoured consistently:

- `ports:` right side → `${API_PORT:-8000}` (was `8000`)
- uvicorn `--port` → `${API_PORT:-8000}` (was `8000`)

Without this, setting `API_PORT=9000` left uvicorn listening on `:8000` inside the container while the watcher targeted `:9000` — silently broken. With all three references aligned, `API_PORT` truly remaps the API host-side and keeps internal traffic consistent.

### Tested locally

- `API_PORT=8000` → API on `localhost:8000`, watcher reaches `http://api:8000` ✅
- `API_PORT=9000` → API on `localhost:9000`, watcher reaches `http://api:9000` ✅
- Full pipeline on `API_PORT=9000`: dropped a markdown file in `data/sources/`, watcher ingested it, 5 facts extracted, central review created relations, agent endpoint at `:9000` returned a correct synthesised answer ✅
- Reverting to `API_PORT=8000` → identical to pre-PR behaviour ✅
