### PR TITLE
feat: self-hosted vLLM profile (vllm_workstation)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,13 +13,19 @@ API_PORT=8000
 HF_TOKEN=
 
 # LLM provider profile — which LiteLLM backend the agent talks to.
-# Options are defined in braindb/config.py::_LLM_PROFILES (currently: nim, deepinfra).
+# Options are defined in braindb/config.py::_LLM_PROFILES
+# (currently: nim, deepinfra, vllm_workstation).
 LLM_PROFILE=deepinfra
 
 # Provider API keys — fill in whichever profile you're using.
 # Get a NIM key at https://build.nvidia.com/, a DeepInfra key at https://deepinfra.com/
 NVIDIA_NIM_API_KEY=
 DEEPINFRA_API_KEY=
+
+# Self-hosted vLLM (vllm_workstation profile) — typically runs without auth,
+# in which case the resolver supplies the literal "EMPTY" placeholder.
+# Set this only if your vLLM was started with --api-key.
+VLLM_API_KEY=
 
 # Optional: override the profile's default model string (e.g. to try a smaller variant).
 # Leave blank to use the profile's built-in default.

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,8 @@ __pycache__/
 *.egg-info/
 dist/
 build/
+.venv/
+venv/
 
 # Test / lint artifacts
 .pytest_cache/

--- a/BRAINDB_GUIDE.md
+++ b/BRAINDB_GUIDE.md
@@ -337,6 +337,7 @@ The agent has these tools internally: `recall_memory`, `quick_search`, `save_fac
 **Setup (pick a provider)**:
 - **DeepInfra (default)**: set `LLM_PROFILE=deepinfra` and `DEEPINFRA_API_KEY=...` in `.env`. Get a key at https://deepinfra.com/
 - **NVIDIA NIM**: set `LLM_PROFILE=nim` and `NVIDIA_NIM_API_KEY=...` in `.env`. Get a key at https://build.nvidia.com/
+- **Self-hosted vLLM**: set `LLM_PROFILE=vllm_workstation` for a vLLM server bound to the Docker host's loopback at `:8002`. No API key needed if the server runs without auth. See [CONTRIBUTING.md](CONTRIBUTING.md) for how to add your own self-hosted profile.
 - Profiles live in `braindb/config.py::_LLM_PROFILES`. Add new providers there (e.g. `together`, `openai`) by adding a dict entry — no code change required.
 - Optional override: set `AGENT_MODEL=` in `.env` to use a non-default model for the active profile.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,6 +51,22 @@ LiteLLM does the heavy lifting — providers are selected by a prefix in the mod
 
 No other code changes required — the agent resolves model and key through `settings.resolved_agent_model` and `settings.resolved_api_key`, which read the active profile.
 
+### Self-hosted OpenAI-compatible servers (vLLM, Ollama, llama.cpp)
+
+For a server you run yourself that speaks the OpenAI REST shape, the profile takes an optional third field, `base_url`, and uses LiteLLM's `openai/` prefix to route through the OpenAI-compatible code path:
+
+```python
+"vllm_workstation": {
+    "model": "openai/cyankiwi/gemma-4-31B-it-AWQ-4bit",
+    "api_key_env": "VLLM_API_KEY",
+    "base_url": "http://host.docker.internal:8002/v1",
+},
+```
+
+When `base_url` points at the Docker host (`host.docker.internal`), the `api` service in [`docker-compose.yml`](docker-compose.yml) needs `extra_hosts: ["host.docker.internal:host-gateway"]` so the container can reach the host's loopback. The compose file in this repo already declares it.
+
+If your server runs without auth, leave the matching `*_API_KEY` env var unset — `settings.resolved_api_key` falls back to the literal `"EMPTY"` for any profile that has a `base_url`, which keeps the OpenAI client happy.
+
 ## Adding a new database migration
 
 BrainDB uses raw-SQL Alembic migrations (no ORM). Current revision is in `alembic/versions/`.

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.12-slim
 
 WORKDIR /app
 
-COPY pyproject.toml .
+COPY pyproject.toml README.md ./
 RUN pip install --no-cache-dir -e .
 
 COPY . .

--- a/braindb/agent/agent.py
+++ b/braindb/agent/agent.py
@@ -49,6 +49,7 @@ def create_braindb_agent() -> Agent:
     model = LitellmModel(
         model=settings.resolved_agent_model,
         api_key=settings.resolved_api_key,
+        base_url=settings.resolved_base_url,
     )
     set_tracing_disabled(disabled=True)
 

--- a/braindb/config.py
+++ b/braindb/config.py
@@ -3,8 +3,9 @@ import os
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 # LLM provider profiles. Flip the whole stack by setting LLM_PROFILE in .env.
-# Each profile is just a LiteLLM model prefix + the env var holding its API key.
-# Adding a new provider is a dict entry, no code change.
+# Each profile is a LiteLLM model prefix + the env var holding its API key,
+# plus an optional base_url for self-hosted OpenAI-compatible servers (vLLM,
+# Ollama, llama.cpp). Adding a new provider is a dict entry, no code change.
 _LLM_PROFILES: dict[str, dict[str, str]] = {
     "nim": {
         "model": "nvidia_nim/google/gemma-4-31b-it",
@@ -13,6 +14,11 @@ _LLM_PROFILES: dict[str, dict[str, str]] = {
     "deepinfra": {
         "model": "deepinfra/google/gemma-4-31B-it",
         "api_key_env": "DEEPINFRA_API_KEY",
+    },
+    "vllm_workstation": {
+        "model": "openai/cyankiwi/gemma-4-31B-it-AWQ-4bit",
+        "api_key_env": "VLLM_API_KEY",
+        "base_url": "http://host.docker.internal:8002/v1",
     },
 }
 
@@ -54,7 +60,17 @@ class Settings(BaseSettings):
 
     @property
     def resolved_api_key(self) -> str:
-        return os.getenv(_LLM_PROFILES[self.llm_profile]["api_key_env"], "")
+        profile = _LLM_PROFILES[self.llm_profile]
+        key = os.getenv(profile["api_key_env"], "")
+        # Self-hosted profiles (vLLM/Ollama) may run without auth, but the
+        # OpenAI client still needs a non-empty key — supply a placeholder.
+        if not key and profile.get("base_url"):
+            return "EMPTY"
+        return key
+
+    @property
+    def resolved_base_url(self) -> str | None:
+        return _LLM_PROFILES[self.llm_profile].get("base_url")
 
 
 settings = Settings()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,13 @@ services:
       AGENT_MODEL: ${AGENT_MODEL:-}
       NVIDIA_NIM_API_KEY: ${NVIDIA_NIM_API_KEY:-}
       DEEPINFRA_API_KEY: ${DEEPINFRA_API_KEY:-}
+      VLLM_API_KEY: ${VLLM_API_KEY:-}
       AGENT_VERBOSE: ${AGENT_VERBOSE:-false}
+    extra_hosts:
+      # Lets self-hosted profiles (e.g. vllm_workstation) reach a server bound
+      # to the Docker host's loopback. Docker Desktop sets this implicitly;
+      # the explicit form keeps the file portable to Linux Docker Engine.
+      - "host.docker.internal:host-gateway"
     ports:
       - "${API_PORT:-8000}:${API_PORT:-8000}"
     volumes:


### PR DESCRIPTION
## Summary
- New `LLM_PROFILE=vllm_workstation` for self-hosted OpenAI-compatible servers (vLLM, Ollama, llama.cpp). Defaults unchanged - `deepinfra` is still the out-of-the-box profile.
- Profile shape gains an optional `base_url` field; `LitellmModel` receives it directly. Self-hosted profiles with no auth get a placeholder `"EMPTY"` api_key automatically.
- `api` service in `docker-compose.yml` declares `host.docker.internal:host-gateway` in `extra_hosts` so the container can reach a server bound to the Docker host's loopback. Implicit on Docker Desktop, explicit form keeps the file portable to Linux.
- Fixes pre-existing Dockerfile bug: `pip install -e .` failed on a fresh build because `pyproject.toml` references `README.md` but the Dockerfile copied only `pyproject.toml` before installing. Now copies both.
- `.gitignore` covers `.venv/` and `venv/`.
- Docs updated: CONTRIBUTING.md gains a "Self-hosted OpenAI-compatible servers" subsection; BRAINDB_GUIDE.md and .env.example reference the new profile.

## Test plan
- [x] `docker compose up -d --build` succeeds on a fresh build (Dockerfile fix verified)
- [x] `LLM_PROFILE=vllm_workstation` end-to-end: stack reaches vLLM via `host.docker.internal:8002`
- [x] Full test suite green inside the container: `pytest -ra` → **38 passed in 12.48s**, including live agent smoke tests through vLLM
- [ ] `LLM_PROFILE=deepinfra` regression check (cloud profile still works on default settings)
