### PR TITLE
Reject missing relation endpoints

### DIFF
--- a/braindb/routers/relations.py
+++ b/braindb/routers/relations.py
@@ -34,9 +34,24 @@ def _or_404(row: dict | None) -> dict:
     return row
 
 
+def _ensure_entities_exist(conn, *entity_ids: UUID) -> None:
+    entity_id_params = tuple(str(entity_id) for entity_id in entity_ids)
+    expected_ids = set(entity_id_params)
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT id FROM entities WHERE id IN (%s, %s)",
+            entity_id_params,
+        )
+        found_ids = {str(row[0]) for row in cur.fetchall()}
+    missing_ids = sorted(expected_ids - found_ids)
+    if missing_ids:
+        raise HTTPException(status_code=404, detail=f"Entity not found: {missing_ids[0]}")
+
+
 @router.post("/api/v1/relations", response_model=RelationRead, status_code=201)
 def create_relation(body: RelationCreate):
     with get_conn() as conn:
+        _ensure_entities_exist(conn, body.from_entity_id, body.to_entity_id)
         with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
             try:
                 cur.execute("""
@@ -53,6 +68,9 @@ def create_relation(body: RelationCreate):
             except psycopg2.errors.UniqueViolation:
                 conn.rollback()
                 raise HTTPException(409, "Relation of this type already exists between these entities")
+            except psycopg2.errors.ForeignKeyViolation:
+                conn.rollback()
+                raise HTTPException(404, "One or both relation endpoints do not exist")
         log_activity(conn, "create", "relation", rid, details={
             "from_entity_id": str(body.from_entity_id),
             "to_entity_id": str(body.to_entity_id),

--- a/tests/test_relations.py
+++ b/tests/test_relations.py
@@ -1,6 +1,8 @@
 """
 Relation CRUD + inbound/outbound listing + type validation.
 """
+import uuid
+
 import requests
 
 
@@ -87,6 +89,25 @@ def test_invalid_relation_type_is_rejected(api, make_fact):
         timeout=10,
     )
     assert r.status_code in (400, 422), f"expected 4xx, got {r.status_code}: {r.text[:200]}"
+
+
+def test_create_relation_rejects_missing_entity(api, make_fact):
+    existing = make_fact("Existing endpoint.")
+    missing_id = str(uuid.uuid4())
+
+    r = requests.post(
+        f"{api}/api/v1/relations",
+        json={
+            "from_entity_id": missing_id,
+            "to_entity_id": existing["id"],
+            "relation_type": "supports",
+            "relevance_score": 0.5,
+        },
+        timeout=10,
+    )
+
+    assert r.status_code == 404
+    assert r.json()["detail"] == f"Entity not found: {missing_id}"
 
 
 def test_all_documented_relation_types_accepted(api, make_fact, make_relation):


### PR DESCRIPTION
## Summary
- validate relation endpoint entity IDs before insert
- return 404 for missing relation endpoints instead of surfacing a database traceback
- add regression coverage for missing relation endpoint IDs

## Tests
- BRAINDB_TEST_URL=http://localhost:8100 python -m pytest tests/test_relations.py -q
- python -m py_compile braindb/routers/relations.py tests/test_relations.py