### PR TITLE
v0.3.0 — Read-only frontend (Reader/Graph/Ops/Ask) + relations endpoint fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,46 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] — 2026-05-25
+
+Headline: a small read-only frontend lands so humans can browse the same
+knowledge graph the agents read and write to. Plus a YouTube walkthrough
+linked from the README, and the merged contribution from @WarGloom that
+tightens up the relations endpoints.
+
+### Added
+
+- **Frontend** (`frontend/`): vanilla-JS, no build step, no npm.
+  - **Reader** — left rail wiki index + elastic-debounced semantic search
+    with type-pill breakdown, central wiki body with citation chips,
+    right-rail Relations panel that resolves every endpoint to a readable
+    chip (type pill + canonical name) rather than a raw UUID.
+  - **Graph** — force-layout view with custom shapes per entity type.
+    Physics is one-shot (off after first settle) and new nodes added on
+    expansion are placed in a deterministic ring around the click target,
+    so the graph never drifts under the user's mouse. Zoom buttons,
+    scroll-wheel zoom, drag-pan, retired-wiki badge in the search dropdown.
+  - **Ops** — pipeline-queue and activity-log tables with actor pills
+    (Maintainer / Writer / Scheduler / Watcher), readable target-wiki +
+    entity chips, zebra stripes, and a NOTE column that distinguishes
+    benign rationale from real errors.
+  - **Ask drawer** — a textarea that posts to the agent endpoint
+    (`POST /api/v1/agent/query`) with the same async semantics as the
+    Claude Code skill (long calls supported).
+  - **Universal entity-chip resolver**: a small async helper is wired into
+    every render site that previously showed a UUID — relations, jobs,
+    log rows, drawer titles. Cached after first fetch.
+- **YouTube walkthrough**: linked from `README.md`
+  ([youtu.be/AJ7iMOj4vvA](https://youtu.be/AJ7iMOj4vvA)).
+- **README**: new "Frontend (optional, read-only)" section with one-line
+  serve instructions.
+
+### Changed
+
+- **Relations endpoint hardening** — merges @WarGloom's
+  [PR #5](https://github.com/dimknaf/braindb/pull/5): missing relation
+  endpoints now reject cleanly instead of returning a confusing 200.
+
 ## [0.2.0] — 2026-05-24
 
 The first substantial release beyond the v0.1.0 memory-store baseline. The

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,6 +87,7 @@ braindb/
 ├── skills/                            # Shipped Claude Code skills
 │   ├── braindb/SKILL.md               # Direct curl-based skill
 │   └── braindb-agent/SKILL.md         # Thin wrapper around the agent endpoint
+├── frontend/                          # Read-only browser UI — vanilla JS, no build
 ├── docker-compose.yml                 # api + watcher services (external PostgreSQL)
 ├── .env                               # Real credentials — DO NOT COMMIT
 └── BRAINDB_GUIDE.md                   # Full API reference with curl examples

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # BrainDB
 
+[![BrainDB walkthrough](https://img.youtube.com/vi/AJ7iMOj4vvA/maxresdefault.jpg)](https://youtu.be/AJ7iMOj4vvA "Watch the BrainDB walkthrough on YouTube")
+
+> **▶ Watch the walkthrough:** [youtu.be/AJ7iMOj4vvA](https://youtu.be/AJ7iMOj4vvA) — Karpathy's LLM wiki idea, on a SQL database, driven by REST APIs.
+
 A memory database and REST API for LLM agents. Store and retrieve thoughts, facts, sources, documents, and behavioral rules — with fuzzy + semantic keyword search, graph traversal up to 3 hops, temporal decay, and always-on rule injection. Built to be driven externally by an LLM via HTTP calls.
 
 It also ships with **its own internal agent** (OpenAI Agents SDK + LiteLLM with pluggable providers — **DeepInfra is the recommended default**, with NIM / local vLLM / others available via config) so external callers can talk to BrainDB in plain English via a single endpoint instead of orchestrating individual API calls.
@@ -306,6 +310,16 @@ provenance to `data/wiki_review/`.)
 automatically. To run without it, bring the stack up excluding the service or
 scale it to 0 (`docker compose up -d --scale wiki_scheduler=0`), exactly as
 you would for the watcher; or point `LLM_PROFILE` at a local model.
+
+## Frontend (optional, read-only)
+
+A small vanilla-JS frontend ships under `frontend/` — no build step. Three views (Reader for browsing wikis, Graph for visual exploration, Ops for watching the maintainer/writer pipeline) plus an Ask drawer that talks to the agent endpoint. Talks to the BrainDB API at `http://localhost:8000`. Serve it from the repo root:
+
+```bash
+cd frontend && python -m http.server 8090
+```
+
+Then open `http://localhost:8090`. See [frontend/README.md](frontend/README.md) for the design notes.
 
 ## Stack
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -24,16 +24,26 @@ If your API lives somewhere other than `localhost:8000`, set `window.BRAINDB_API
 
 | File | Purpose |
 |---|---|
-| `index.html` | Layout shell: top bar with Reader / Ops tabs, the Reader grid (rail / wiki body / relations), the Ops grid (stats / queue / log / rules), and two slide-over drawers (entity / Ask). |
-| `style.css` | Design language: near-monochrome palette, refined serif for body, clean grotesque for UI, hairline rules, one restrained accent. Light + dark via `data-theme` on `<html>`. |
+| `index.html` | Layout shell: top bar with Reader / Graph / Ops tabs, the Reader grid (rail / wiki body / relations), the Graph view (Cytoscape canvas + toolbar + legend), the Ops grid (stats / queue / log / rules), and two slide-over drawers (entity / Ask). Loads Cytoscape + fCoSE from a CDN. |
+| `style.css` | Design language: near-monochrome palette, refined serif for body, clean grotesque for UI, hairline rules, one restrained accent. Light + dark via `data-theme` on `<html>`. Graph view tokens included. |
 | `wiki-render.js` | Small Markdown-ish renderer specialised for the BrainDB wiki body grammar — `<!-- wiki:meta -->`, headings, `> **Summary:** / **Disambiguation:**` callouts, `<!-- section:slug -->` dividers, GFM tables, lists, `**bold**`, `` `code` ``, and `[[ref:UUID]]` / `[[ref:UUID|display]]` citation chips (tolerant of the grouped form). |
-| `app.js` | Data layer + routing + Ops auto-refresh + Ask drawer wiring. ES module; imports `wiki-render.js`. |
+| `graph.js` | Cytoscape.js integration: per-entity-type shapes/colours, edge-label-on-hover, click → entity drawer, double-click → expand 1-hop neighbourhood, 300-node soft cap. |
+| `app.js` | Data layer + routing + Ops auto-refresh + Ask drawer wiring + Graph tab wiring. ES module; imports `wiki-render.js` and `graph.js`. |
 
 ## Keyboard
 
 - `/` — focus the search box (Reader)
 - `Cmd/Ctrl+K` — open the Ask drawer
 - `Esc` — close any open drawer
+- `F` — fit graph to viewport (Graph tab)
+
+## Graph tab — quick tour
+
+- Open a wiki in **Reader**, then click the **Graph** tab → the graph seeds with that wiki and its direct neighbours (keywords, facts, sources).
+- Cold-start the Graph tab → empty canvas with a search box; pick a result to seed.
+- **Click** any node → opens the entity drawer (same one Reader uses).
+- **Double-click** a node → expands its 1-hop neighbourhood.
+- Scroll to zoom, drag empty space to pan. Soft-capped at 300 nodes.
 
 ## Endpoints used
 
@@ -50,3 +60,10 @@ Read-only except where intentional:
 - `POST /api/v1/agent/query` — the Ask drawer
 
 No `/memory/sql`. No direct database access. No write outside the user-driven Ask drawer.
+
+## External dependencies (CDN, optional)
+
+- [Cytoscape.js](https://js.cytoscape.org/) 3.30.4 — graph rendering for the Graph tab.
+- [cytoscape-fcose](https://github.com/iVis-at-Bilkent/cytoscape.js-fcose) 2.2.0 — force-directed layout for the Graph tab.
+
+Both are loaded from `unpkg.com` in `index.html` with pinned versions. If the CDN is unreachable, the Graph tab shows an error message and the rest of the app (Reader / Ops / Ask) continues to work.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,52 @@
+# BrainDB frontend
+
+A thin, read-mostly browser UI for BrainDB. Vanilla HTML / CSS / JS — no build, no npm, no framework.
+
+## Run
+
+The BrainDB backend must be running first (default: `http://localhost:8000`). From the repo root:
+
+```bash
+python -m http.server 8090 -d frontend
+```
+
+Then open <http://localhost:8090>.
+
+That's it. The frontend is a static page that talks to the API directly via `fetch`. CORS is already open on the backend.
+
+> If `8090` is in use on your machine, pick any free port: `python -m http.server <PORT> -d frontend`. (Avoid `8080` on Windows with Docker Desktop installed — it's commonly held by the WSL backend.)
+
+## Pointing at a non-local backend
+
+If your API lives somewhere other than `localhost:8000`, set `window.BRAINDB_API_URL` before `app.js` loads — e.g. inject a small `<script>window.BRAINDB_API_URL="https://my-host:8000"</script>` before the module tag in `index.html`.
+
+## What's in here
+
+| File | Purpose |
+|---|---|
+| `index.html` | Layout shell: top bar with Reader / Ops tabs, the Reader grid (rail / wiki body / relations), the Ops grid (stats / queue / log / rules), and two slide-over drawers (entity / Ask). |
+| `style.css` | Design language: near-monochrome palette, refined serif for body, clean grotesque for UI, hairline rules, one restrained accent. Light + dark via `data-theme` on `<html>`. |
+| `wiki-render.js` | Small Markdown-ish renderer specialised for the BrainDB wiki body grammar — `<!-- wiki:meta -->`, headings, `> **Summary:** / **Disambiguation:**` callouts, `<!-- section:slug -->` dividers, GFM tables, lists, `**bold**`, `` `code` ``, and `[[ref:UUID]]` / `[[ref:UUID|display]]` citation chips (tolerant of the grouped form). |
+| `app.js` | Data layer + routing + Ops auto-refresh + Ask drawer wiring. ES module; imports `wiki-render.js`. |
+
+## Keyboard
+
+- `/` — focus the search box (Reader)
+- `Cmd/Ctrl+K` — open the Ask drawer
+- `Esc` — close any open drawer
+
+## Endpoints used
+
+Read-only except where intentional:
+
+- `GET /api/v1/entities?entity_type=wiki` — wiki index
+- `GET /api/v1/entities/{id}` — full entity (wiki body, fact, thought, …)
+- `GET /api/v1/entities/{id}/relations` — relations of one entity
+- `GET /api/v1/wiki/jobs` — Ops queue
+- `GET /api/v1/memory/log` — Ops activity log
+- `GET /api/v1/memory/stats` — Ops stats strip
+- `GET /api/v1/memory/rules` — Ops rules list
+- `POST /api/v1/memory/context` — search (the modern keyword-mediated path)
+- `POST /api/v1/agent/query` — the Ask drawer
+
+No `/memory/sql`. No direct database access. No write outside the user-driven Ask drawer.

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -6,6 +6,7 @@
 // ============================================================
 
 import { renderWiki, extractSections, consistencyCheck } from "./wiki-render.js";
+import * as graph from "./graph.js";
 
 const API = (window.BRAINDB_API_URL || "http://localhost:8000") + "/api/v1";
 
@@ -50,6 +51,25 @@ function escapeHtml(s) {
   return String(s || "")
     .replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;")
     .replace(/"/g, "&quot;").replace(/'/g, "&#39;");
+}
+
+// Build a clean human-readable snippet from an entity's content.
+// Strips the leading `<!-- wiki:meta … -->` comment, the `# Title` line, and
+// blockquote markers; for wikis it prefers the `> **Summary:** …` callout text.
+function entitySnippet(content, isWiki = false) {
+  if (!content) return "";
+  let body = String(content);
+  // Strip a single leading HTML comment (the wiki:meta header).
+  body = body.replace(/^\s*<!--[\s\S]*?-->\s*/, "");
+  if (isWiki) {
+    const sum = body.match(/^>\s*\*\*Summary[:\s]\*\*\s*([\s\S]+?)(?:\n>|\n\n|$)/im);
+    if (sum) return sum[1].replace(/\s+/g, " ").trim().slice(0, 160);
+  }
+  const cleaned = body
+    .split(/\r?\n/)
+    .map(l => l.replace(/^#+\s*/, "").replace(/^>\s*/, "").trim())
+    .filter(l => l.length > 0 && !/^<!--/.test(l));
+  return (cleaned[0] || "").slice(0, 160);
 }
 
 // Pull a clean wiki name from the preview's first lines without a full fetch.
@@ -109,7 +129,11 @@ function initTabs() {
   $$(".tab").forEach(t => t.addEventListener("click", () => {
     const name = t.dataset.tab;
     if (name === "ops") location.hash = "#/ops";
-    else location.hash = "#/";
+    else if (name === "graph") {
+      // Snap to the currently-open wiki if there is one
+      const cur = parseHash();
+      location.hash = cur.route === "wiki" ? `#/graph/${cur.id}` : "#/graph";
+    } else location.hash = "#/";
   }));
 }
 
@@ -119,6 +143,8 @@ function initTabs() {
 function parseHash() {
   const h = (location.hash || "#/").slice(1);
   if (h.startsWith("/wiki/")) return { route: "wiki", id: h.slice(6) };
+  if (h.startsWith("/graph/")) return { route: "graph", id: h.slice(7) };
+  if (h.startsWith("/graph")) return { route: "graph" };
   if (h.startsWith("/ops")) return { route: "ops" };
   return { route: "reader" };
 }
@@ -128,6 +154,11 @@ async function handleRoute() {
   if (r.route === "ops") {
     setTab("ops");
     await loadOps();
+    return;
+  }
+  if (r.route === "graph") {
+    setTab("graph");
+    await openGraph(r.id || null);
     return;
   }
   setTab("reader");
@@ -213,6 +244,7 @@ async function openWiki(id) {
       ${cc.consistent
         ? `<span class="badge consistent">CONSISTENT ✓</span>`
         : `<span class="badge inconsistent">${cc.inline} inline / ${cc.relations} relations</span>`}
+      <a class="meta-piece graph-link" href="#/graph/${id}">Show in graph →</a>
     </div>
   `;
 
@@ -380,54 +412,182 @@ function initDrawers() {
 // ============================================================
 // Search (uses /memory/context)
 // ============================================================
+
+// Extracted so BOTH the submit handler and the live-debounce can call it
+// directly. The previous `form.requestSubmit()` indirection was fragile
+// (silent InvalidStateError inside setTimeout → debounce appeared dead).
+async function runReaderSearch() {
+  const input = $("#search-input");
+  const results = $("#search-results");
+  const q = input.value.trim();
+  if (!q) { results.hidden = true; return; }
+  results.hidden = false;
+  results.innerHTML = `<div class="results-empty">Searching…</div>`;
+  try {
+    const queries = [q, ...q.split(/\s+/).filter(w => w.length > 2)].slice(0, 4);
+    const dedup = [...new Set(queries)];
+    const res = await data.search(dedup);
+    const items = res.items || res || [];
+    if (items.length === 0) {
+      results.innerHTML = `<div class="results-empty">No matches.</div>`;
+      return;
+    }
+    // Type-breakdown badge row so the variety of result types is obvious.
+    const breakdown = {};
+    for (const it of items) {
+      const t = it.entity_type || "?";
+      breakdown[t] = (breakdown[t] || 0) + 1;
+    }
+    const breakdownHtml = `
+      <div class="result-breakdown">
+        ${Object.entries(breakdown).sort((a,b)=>b[1]-a[1]).map(
+          ([t, n]) => `<span class="type-pill type-${escapeHtml(t)}">${escapeHtml(t)} ${n}</span>`
+        ).join("")}
+      </div>`;
+    // Result rows
+    const rowsHtml = items.slice(0, 30).map(it => {
+      const id = it.id || it.entity_id;
+      const type = it.entity_type || "?";
+      const isWiki = type === "wiki";
+      const snippet = entitySnippet(it.content, isWiki);
+      const name = isWiki
+        ? (previewCanonicalName(it.content) || snippet.slice(0, 80) || id.slice(0, 8))
+        : (snippet.slice(0, 80) || id.slice(0, 8));
+      const shortPreview = (snippet && snippet !== name) ? snippet : "";
+      return `
+        <div class="result-item" data-id="${escapeHtml(id)}" data-type="${escapeHtml(type)}">
+          <span class="type-pill type-${escapeHtml(type)}">${escapeHtml(type)}</span>
+          <span class="result-name">${escapeHtml(name)}</span>
+          ${shortPreview ? `<div class="result-preview">${escapeHtml(shortPreview)}</div>` : ""}
+        </div>`;
+    }).join("");
+    results.innerHTML = breakdownHtml + rowsHtml;
+    // Wire row clicks
+    $$(".result-item", results).forEach(row => {
+      row.addEventListener("click", () => {
+        if (row.dataset.type === "wiki") location.hash = `#/wiki/${row.dataset.id}`;
+        else openEntityDrawer(row.dataset.id);
+      });
+    });
+  } catch (e) {
+    console.error("Reader search failed:", e);
+    results.innerHTML = `<div class="results-empty">Search failed: ${escapeHtml(e.message)}</div>`;
+  }
+}
+
 function initSearch() {
   const form = $("#search-form");
   const input = $("#search-input");
   const results = $("#search-results");
 
-  form.addEventListener("submit", async (ev) => {
-    ev.preventDefault();
+  form.addEventListener("submit", (ev) => { ev.preventDefault(); runReaderSearch(); });
+
+  // Live debounced search — calls runReaderSearch directly (no form.requestSubmit
+  // indirection, which was silently failing inside setTimeout). 180 ms feels
+  // live without hammering the server.
+  let timer = null;
+  input.addEventListener("input", () => {
+    clearTimeout(timer);
+    if (!input.value.trim()) { results.hidden = true; return; }
+    timer = setTimeout(runReaderSearch, 180);
+  });
+}
+
+// ============================================================
+// Graph view
+// ============================================================
+let graphSearchTimer = null;
+let graphSeeded = false;
+
+async function openGraph(seedId) {
+  // Defer one animation frame so the browser has actually laid out the now-
+  // visible #graph section. Otherwise Cytoscape mounts into a 0×0 container,
+  // computes layout in degenerate coordinates, and fit() centres on garbage.
+  await new Promise(resolve => requestAnimationFrame(() => resolve()));
+  const container = $("#graph-canvas");
+  const cy = graph.ensureMounted(container, (nodeId) => openEntityDrawer(nodeId));
+  if (!cy) return; // CDN failed
+
+  // Cold start (no explicit seed): pick the first wiki from the cached index
+  // so the user sees the graph features in action immediately instead of a
+  // blank canvas. They can change the seed via search or "Reset".
+  if (!seedId && !graphSeeded && wikiIndexCache && wikiIndexCache.length) {
+    seedId = wikiIndexCache[0].id;
+  }
+  if (seedId && seedId !== graphSeeded) {
+    graphSeeded = seedId;
+    await graph.seed(seedId, (msg) => { $("#graph-status").textContent = msg; });
+  }
+}
+
+function initGraph() {
+  // Toolbar buttons
+  $("#graph-fit").addEventListener("click", () => graph.fit());
+  $("#graph-reset").addEventListener("click", () => {
+    graph.reset();
+    graphSeeded = false;
+    location.hash = "#/graph";
+  });
+  $("#graph-hide-kw").addEventListener("change", (e) => graph.toggleKeywords(e.target.checked));
+
+  // Search box (graph-specific) — debounced /memory/context call
+  const form = $("#graph-search-form");
+  const input = $("#graph-search-input");
+  const results = $("#graph-search-results");
+
+  async function runSearch() {
     const q = input.value.trim();
     if (!q) { results.hidden = true; return; }
     results.hidden = false;
-    results.innerHTML = `<div class="results-empty">Searching…</div>`;
-
+    results.innerHTML = `<div class="result-empty">Searching…</div>`;
     try {
-      // Multi-query: pass the raw input plus split words as narrow queries.
-      const queries = [q, ...q.split(/\s+/).filter(w => w.length > 2)].slice(0, 4);
-      const dedup = [...new Set(queries)];
-      const res = await data.search(dedup);
-      const items = res.items || res || [];
-      if (items.length === 0) {
-        results.innerHTML = `<div class="results-empty">No matches.</div>`;
+      const items = await graph.searchSeeds(q);
+      if (!items.length) {
+        results.innerHTML = `<div class="result-empty">No matches.</div>`;
         return;
       }
       results.innerHTML = "";
-      for (const it of items.slice(0, 30)) {
-        const row = document.createElement("div");
-        row.className = "result-item";
+      for (const it of items) {
         const id = it.id || it.entity_id;
         const type = it.entity_type || "?";
-        const previewText = (it.content || it.summary || it.preview || "").toString().slice(0, 140);
-        row.innerHTML = `
-          <span class="result-type">${escapeHtml(type)}</span>
-          ${escapeHtml(previewCanonicalName(it.content) || (previewText.split("\n")[0] || id.slice(0, 8)))}
-          ${previewText ? `<span class="result-preview">${escapeHtml(previewText)}</span>` : ""}
-        `;
-        row.addEventListener("click", () => {
-          if (type === "wiki") location.hash = `#/wiki/${id}`;
-          else openEntityDrawer(id);
+        const label = (previewCanonicalName(it.content) || (it.content || "").split("\n")[0] || id).slice(0, 60);
+        const row = document.createElement("div");
+        row.className = "result-item";
+        row.innerHTML = `<span class="result-type">${escapeHtml(type)}</span> ${escapeHtml(label)}`;
+        row.addEventListener("click", async () => {
+          results.hidden = true;
+          input.value = "";
+          location.hash = `#/graph/${id}`;
         });
         results.appendChild(row);
       }
     } catch (e) {
-      results.innerHTML = `<div class="results-empty">Search failed: ${escapeHtml(e.message)}</div>`;
+      results.innerHTML = `<div class="result-empty">Search failed: ${escapeHtml(e.message)}</div>`;
+    }
+  }
+
+  form.addEventListener("submit", (ev) => { ev.preventDefault(); runSearch(); });
+  input.addEventListener("input", () => {
+    clearTimeout(graphSearchTimer);
+    if (!input.value.trim()) { results.hidden = true; return; }
+    graphSearchTimer = setTimeout(runSearch, 250);
+  });
+
+  // F = fit
+  document.addEventListener("keydown", (ev) => {
+    const tag = (ev.target.tagName || "").toLowerCase();
+    if (tag === "input" || tag === "textarea") return;
+    if (location.hash.startsWith("#/graph") && (ev.key === "f" || ev.key === "F")) {
+      ev.preventDefault();
+      graph.fit();
     }
   });
 
-  // Submit on Enter (already default), but also live-clear when input emptied
-  input.addEventListener("input", () => {
-    if (!input.value.trim()) results.hidden = true;
+  // Theme change re-styles the graph
+  const themeBtn = $("#theme-toggle");
+  themeBtn.addEventListener("click", () => {
+    // app.js's initTheme handler runs first; refresh graph styles right after
+    setTimeout(() => graph.refreshStyle(), 0);
   });
 }
 
@@ -651,6 +811,7 @@ async function boot() {
   initDrawers();
   initSearch();
   initAsk();
+  initGraph();
   initKeys();
 
   // Initial data load: the wiki index is cheap and needed by Reader.

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1,0 +1,667 @@
+// ============================================================
+// app.js — BrainDB read-only frontend
+//   - Data layer: thin fetch wrappers over the existing API
+//   - Routing: hash-based (#/wiki/<id>, #/ops, #/)
+//   - Reader, Ops, and Ask drawer wiring
+// ============================================================
+
+import { renderWiki, extractSections, consistencyCheck } from "./wiki-render.js";
+
+const API = (window.BRAINDB_API_URL || "http://localhost:8000") + "/api/v1";
+
+// ============================================================
+// Data layer
+// ============================================================
+async function api(path, opts = {}) {
+  const r = await fetch(API + path, opts);
+  if (!r.ok) {
+    let body = "";
+    try { body = await r.text(); } catch {}
+    throw new Error(`HTTP ${r.status} ${r.statusText} on ${path}\n${body.slice(0, 400)}`);
+  }
+  return r.json();
+}
+const apiGet = (path) => api(path);
+const apiPost = (path, body) => api(path, {
+  method: "POST",
+  headers: { "Content-Type": "application/json" },
+  body: JSON.stringify(body),
+});
+
+const data = {
+  listWikis: () => apiGet("/entities?entity_type=wiki&limit=200"),
+  entity: (id) => apiGet(`/entities/${id}`),
+  relations: (id) => apiGet(`/entities/${id}/relations`),
+  search: (queries) => apiPost("/memory/context", { queries, max_depth: 1 }),
+  jobs: () => apiGet("/wiki/jobs?limit=200"),
+  log: () => apiGet("/memory/log?limit=50"),
+  stats: () => apiGet("/memory/stats"),
+  rules: () => apiGet("/memory/rules"),
+  agent: (query) => apiPost("/agent/query", { query }),
+};
+
+// ============================================================
+// Helpers
+// ============================================================
+const $ = (sel, root = document) => root.querySelector(sel);
+const $$ = (sel, root = document) => Array.from(root.querySelectorAll(sel));
+
+function escapeHtml(s) {
+  return String(s || "")
+    .replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;").replace(/'/g, "&#39;");
+}
+
+// Pull a clean wiki name from the preview's first lines without a full fetch.
+// Prefers the `# Title` body line (always clean) over the meta header, because
+// LLM emitters sometimes write multi-word canonical_name VALUES unquoted, e.g.
+// `canonical_name=Value Investing language=en …`, which a naive regex
+// truncates to the first word.
+function previewCanonicalName(preview) {
+  if (!preview) return null;
+  const h = preview.match(/^#\s+(.+)$/m);
+  if (h) return h[1].trim();
+  // Fallback: parse the meta header tolerantly (quoted OR unquoted multi-word).
+  const m = preview.match(/canonical_name=(?:"([^"]+)"|([^\s][^>]*?))(?=\s+\w+=|\s*-->|$)/);
+  if (m) return (m[1] || m[2] || "").trim();
+  return null;
+}
+
+function isRetired(wiki) {
+  // The list endpoint returns previews + the entity row; importance≈0 + a
+  // visible "redirect_to:" line in the preview is a strong retirement signal.
+  // Defensive — fall back to false.
+  if (wiki.importance != null && wiki.importance < 0.05) return true;
+  return false;
+}
+
+// ============================================================
+// Theme
+// ============================================================
+function initTheme() {
+  const saved = localStorage.getItem("braindb-theme");
+  if (saved === "dark") document.documentElement.dataset.theme = "dark";
+  $("#theme-toggle").addEventListener("click", () => {
+    const cur = document.documentElement.dataset.theme;
+    if (cur === "dark") {
+      delete document.documentElement.dataset.theme;
+      localStorage.setItem("braindb-theme", "light");
+    } else {
+      document.documentElement.dataset.theme = "dark";
+      localStorage.setItem("braindb-theme", "dark");
+    }
+  });
+}
+
+// ============================================================
+// Tabs
+// ============================================================
+function setTab(name) {
+  $$(".tab").forEach(t => t.classList.toggle("is-active", t.dataset.tab === name));
+  $$(".view").forEach(v => {
+    const on = v.id === name;
+    v.classList.toggle("is-active", on);
+    v.hidden = !on;
+  });
+}
+
+function initTabs() {
+  $$(".tab").forEach(t => t.addEventListener("click", () => {
+    const name = t.dataset.tab;
+    if (name === "ops") location.hash = "#/ops";
+    else location.hash = "#/";
+  }));
+}
+
+// ============================================================
+// Routing
+// ============================================================
+function parseHash() {
+  const h = (location.hash || "#/").slice(1);
+  if (h.startsWith("/wiki/")) return { route: "wiki", id: h.slice(6) };
+  if (h.startsWith("/ops")) return { route: "ops" };
+  return { route: "reader" };
+}
+
+async function handleRoute() {
+  const r = parseHash();
+  if (r.route === "ops") {
+    setTab("ops");
+    await loadOps();
+    return;
+  }
+  setTab("reader");
+  if (r.route === "wiki") {
+    await openWiki(r.id);
+  }
+}
+
+// ============================================================
+// Reader — wiki index
+// ============================================================
+let wikiIndexCache = null;
+
+async function loadWikiIndex() {
+  const items = await data.listWikis();
+  // items is a list of entity rows with `content` containing the preview
+  wikiIndexCache = items;
+  renderWikiIndex(items);
+}
+
+function renderWikiIndex(items) {
+  const ul = $("#wiki-index");
+  ul.innerHTML = "";
+  const sorted = [...items].sort((a, b) => {
+    const an = previewCanonicalName(a.content) || a.id;
+    const bn = previewCanonicalName(b.content) || b.id;
+    return an.localeCompare(bn);
+  });
+  for (const w of sorted) {
+    const li = document.createElement("li");
+    const name = previewCanonicalName(w.content) || w.id.slice(0, 8);
+    li.dataset.id = w.id;
+    li.textContent = name;
+    if (isRetired(w)) {
+      const tag = document.createElement("span");
+      tag.className = "retired-tag";
+      tag.textContent = "retired";
+      li.appendChild(tag);
+    }
+    li.addEventListener("click", () => {
+      location.hash = `#/wiki/${w.id}`;
+    });
+    ul.appendChild(li);
+  }
+}
+
+function markActiveInIndex(id) {
+  $$("#wiki-index li").forEach(li => li.classList.toggle("is-active", li.dataset.id === id));
+}
+
+// ============================================================
+// Reader — open one wiki
+// ============================================================
+async function openWiki(id) {
+  markActiveInIndex(id);
+  const view = $("#wiki-view");
+  view.innerHTML = '<div class="empty">Loading…</div>';
+
+  let entity, relations;
+  try {
+    [entity, relations] = await Promise.all([data.entity(id), data.relations(id)]);
+  } catch (e) {
+    view.innerHTML = `<div class="empty">Failed to load wiki:<br><code>${escapeHtml(e.message)}</code></div>`;
+    return;
+  }
+
+  const body = entity.content || "";
+  const rendered = renderWiki(body);
+  const meta = rendered.meta || {};
+
+  // Consistency: compare inline refs to `summarises` relations
+  const summarisesIds = (relations || [])
+    .filter(r => r.relation_type === "summarises")
+    .map(r => r.to_entity_id);
+  const cc = consistencyCheck(body, summarisesIds);
+
+  const metaStrip = `
+    <div class="wiki-meta">
+      ${meta.canonical_name ? `<span class="meta-piece">${escapeHtml(meta.canonical_name)}</span>` : ""}
+      ${meta.language ? `<span class="meta-piece">${escapeHtml(meta.language)}</span>` : ""}
+      ${entity.revision != null ? `<span class="meta-piece">rev ${entity.revision}</span>` : ""}
+      ${entity.retired_at ? `<span class="badge retired">retired</span>` : ""}
+      ${cc.consistent
+        ? `<span class="badge consistent">CONSISTENT ✓</span>`
+        : `<span class="badge inconsistent">${cc.inline} inline / ${cc.relations} relations</span>`}
+    </div>
+  `;
+
+  view.innerHTML = `
+    <div class="wiki-content">
+      ${metaStrip}
+      ${rendered.html}
+    </div>
+  `;
+
+  // Wire citation chips: clicking opens the entity drawer
+  $$(".ref-chip", view).forEach(a => {
+    a.addEventListener("click", (ev) => {
+      ev.preventDefault();
+      openEntityDrawer(a.dataset.ref);
+    });
+  });
+
+  // Render relations panel
+  renderRelations(relations);
+}
+
+// ============================================================
+// Reader — relations panel
+// ============================================================
+function renderRelations(relations) {
+  const panel = $("#relations-panel");
+  const body = $("#relations-body");
+  body.innerHTML = "";
+
+  if (!relations || relations.length === 0) {
+    panel.hidden = true;
+    return;
+  }
+
+  // Group by relation_type
+  const groups = {};
+  for (const r of relations) {
+    (groups[r.relation_type] ||= []).push(r);
+  }
+
+  for (const [type, rows] of Object.entries(groups).sort()) {
+    const g = document.createElement("div");
+    g.className = "relations-group";
+    const h = document.createElement("h4");
+    h.textContent = `${type} (${rows.length})`;
+    g.appendChild(h);
+    for (const r of rows) {
+      const row = document.createElement("div");
+      row.className = "relation-row";
+      row.dataset.id = r.to_entity_id || r.from_entity_id;
+      row.innerHTML = `
+        <div>${escapeHtml(r.to_entity_label || r.from_entity_label || r.to_entity_id || r.from_entity_id)}</div>
+        ${r.description ? `<span class="preview">${escapeHtml(r.description)}</span>` : ""}
+      `;
+      row.addEventListener("click", () => openEntityDrawer(row.dataset.id));
+      g.appendChild(row);
+    }
+    body.appendChild(g);
+  }
+
+  panel.hidden = false;
+}
+
+// ============================================================
+// Entity drawer (for refs + relation rows)
+// ============================================================
+async function openEntityDrawer(id) {
+  const drawer = $("#entity-drawer");
+  const title = $("#entity-drawer-title");
+  const body = $("#entity-drawer-body");
+  title.textContent = id.slice(0, 8) + "…";
+  body.innerHTML = '<div class="empty">Loading…</div>';
+  openDrawer(drawer);
+
+  let entity, relations;
+  try {
+    [entity, relations] = await Promise.all([data.entity(id), data.relations(id).catch(() => [])]);
+  } catch (e) {
+    body.innerHTML = `<div class="empty">Failed to load entity:<br><code>${escapeHtml(e.message)}</code></div>`;
+    return;
+  }
+
+  title.textContent = entity.entity_type
+    ? `${entity.entity_type} · ${id.slice(0, 8)}`
+    : id.slice(0, 8);
+
+  const sourcePill = entity.source
+    ? `<span class="pill">source: ${escapeHtml(entity.source)}</span>` : "";
+  const certPill = entity.certainty != null
+    ? `<span class="pill">certainty: ${entity.certainty}</span>` : "";
+  const impPill = entity.importance != null
+    ? `<span class="pill">importance: ${entity.importance}</span>` : "";
+
+  const isWiki = entity.entity_type === "wiki";
+  const rendered = renderWiki(entity.content || "");
+  const contentHtml = isWiki
+    ? `<div class="wiki-content">${rendered.html}</div>`
+    : `<pre>${escapeHtml(entity.content || "")}</pre>`;
+
+  let relationsHtml = "";
+  if (relations && relations.length) {
+    const groups = {};
+    for (const r of relations) (groups[r.relation_type] ||= []).push(r);
+    const groupHtml = Object.entries(groups).sort().map(([type, rows]) => {
+      const items = rows.map(r => {
+        const target = r.to_entity_id || r.from_entity_id;
+        const label = r.to_entity_label || r.from_entity_label || target;
+        return `<div class="relation-row" data-id="${target}"><div>${escapeHtml(label)}</div></div>`;
+      }).join("");
+      return `<div class="relations-group"><h4>${type} (${rows.length})</h4>${items}</div>`;
+    }).join("");
+    relationsHtml = `<div class="entity-section"><h4>Relations</h4>${groupHtml}</div>`;
+  }
+
+  body.innerHTML = `
+    <div class="entity-meta">${sourcePill}${certPill}${impPill}</div>
+    <div class="entity-section">
+      <h4>Content</h4>
+      ${contentHtml}
+    </div>
+    ${relationsHtml}
+  `;
+
+  // Drill-down: clicking a relation in the drawer swaps the drawer to that entity
+  $$(".relation-row", body).forEach(row => {
+    row.addEventListener("click", () => openEntityDrawer(row.dataset.id));
+  });
+  // Citation chips inside the drawer also drill in
+  $$(".ref-chip", body).forEach(a => {
+    a.addEventListener("click", (ev) => {
+      ev.preventDefault();
+      openEntityDrawer(a.dataset.ref);
+    });
+  });
+}
+
+// ============================================================
+// Drawer plumbing
+// ============================================================
+function openDrawer(drawer) {
+  drawer.hidden = false;
+  $("#backdrop").hidden = false;
+}
+function closeDrawer(drawer) {
+  drawer.hidden = true;
+  // Hide the backdrop only if no drawer is open
+  if ($("#entity-drawer").hidden && $("#ask-drawer").hidden) {
+    $("#backdrop").hidden = true;
+  }
+}
+function initDrawers() {
+  $$(".drawer-close").forEach(b => {
+    b.addEventListener("click", () => {
+      const which = b.dataset.close;
+      closeDrawer($(`#${which}-drawer`));
+    });
+  });
+  $("#backdrop").addEventListener("click", () => {
+    closeDrawer($("#entity-drawer"));
+    closeDrawer($("#ask-drawer"));
+  });
+}
+
+// ============================================================
+// Search (uses /memory/context)
+// ============================================================
+function initSearch() {
+  const form = $("#search-form");
+  const input = $("#search-input");
+  const results = $("#search-results");
+
+  form.addEventListener("submit", async (ev) => {
+    ev.preventDefault();
+    const q = input.value.trim();
+    if (!q) { results.hidden = true; return; }
+    results.hidden = false;
+    results.innerHTML = `<div class="results-empty">Searching…</div>`;
+
+    try {
+      // Multi-query: pass the raw input plus split words as narrow queries.
+      const queries = [q, ...q.split(/\s+/).filter(w => w.length > 2)].slice(0, 4);
+      const dedup = [...new Set(queries)];
+      const res = await data.search(dedup);
+      const items = res.items || res || [];
+      if (items.length === 0) {
+        results.innerHTML = `<div class="results-empty">No matches.</div>`;
+        return;
+      }
+      results.innerHTML = "";
+      for (const it of items.slice(0, 30)) {
+        const row = document.createElement("div");
+        row.className = "result-item";
+        const id = it.id || it.entity_id;
+        const type = it.entity_type || "?";
+        const previewText = (it.content || it.summary || it.preview || "").toString().slice(0, 140);
+        row.innerHTML = `
+          <span class="result-type">${escapeHtml(type)}</span>
+          ${escapeHtml(previewCanonicalName(it.content) || (previewText.split("\n")[0] || id.slice(0, 8)))}
+          ${previewText ? `<span class="result-preview">${escapeHtml(previewText)}</span>` : ""}
+        `;
+        row.addEventListener("click", () => {
+          if (type === "wiki") location.hash = `#/wiki/${id}`;
+          else openEntityDrawer(id);
+        });
+        results.appendChild(row);
+      }
+    } catch (e) {
+      results.innerHTML = `<div class="results-empty">Search failed: ${escapeHtml(e.message)}</div>`;
+    }
+  });
+
+  // Submit on Enter (already default), but also live-clear when input emptied
+  input.addEventListener("input", () => {
+    if (!input.value.trim()) results.hidden = true;
+  });
+}
+
+// ============================================================
+// Ops view
+// ============================================================
+let opsTimer = null;
+
+async function loadOps() {
+  // Stop any prior auto-refresh
+  if (opsTimer) clearInterval(opsTimer);
+
+  await Promise.all([loadStats(), loadJobs(), loadLog(), loadRules()]);
+  opsTimer = setInterval(() => {
+    loadJobs();
+    loadLog();
+  }, 30_000);
+}
+
+async function loadStats() {
+  try {
+    const s = await data.stats();
+    const counts = s.entity_counts || {};
+    const entries = Object.entries(counts);
+    const html = entries.map(([k, v]) => `
+      <div class="stat">
+        <div class="v">${v}</div>
+        <div class="k">${escapeHtml(k)}</div>
+      </div>
+    `).join("");
+    $("#ops-stats").innerHTML = html || `<div class="empty">No stats.</div>`;
+  } catch (e) {
+    console.error("loadStats failed:", e);
+    $("#ops-stats").innerHTML = `<div class="empty">${escapeHtml(e.message)}</div>`;
+  }
+}
+
+async function loadJobs() {
+  try {
+    const jobs = await data.jobs();
+    const items = jobs.items || jobs || [];
+    if (items.length === 0) {
+      $("#ops-jobs").innerHTML = `<div class="empty">Queue empty.</div>`;
+      return;
+    }
+    const rows = items.slice(0, 100).map(j => {
+      const cls = (j.status === "pending" && j.job_type === "consolidate")
+        ? "highlight-consolidate" : "";
+      return `
+        <tr class="${cls}">
+          <td class="id-cell" title="${escapeHtml(j.id)}">${escapeHtml((j.id || "").slice(0, 8))}</td>
+          <td>${escapeHtml(j.job_type || "")}</td>
+          <td>${escapeHtml(j.status || "")}</td>
+          <td class="id-cell">${escapeHtml((j.target_wiki_id || "").slice(0, 8))}</td>
+          <td>${escapeHtml(j.created_at || "")}</td>
+          <td>${j.attempts != null ? j.attempts : ""}</td>
+          <td class="context">${escapeHtml(j.last_error || "")}</td>
+        </tr>
+      `;
+    }).join("");
+    $("#ops-jobs").innerHTML = `
+      <table class="ops-table">
+        <thead><tr>
+          <th>id</th><th>type</th><th>status</th><th>target</th>
+          <th>created</th><th>tries</th><th>last_error</th>
+        </tr></thead>
+        <tbody>${rows}</tbody>
+      </table>
+    `;
+  } catch (e) {
+    console.error("loadJobs failed:", e);
+    $("#ops-jobs").innerHTML = `<div class="empty">${escapeHtml(e.message)}</div>`;
+  }
+}
+
+async function loadLog() {
+  try {
+    const log = await data.log();
+    const items = log.items || log || [];
+    if (items.length === 0) {
+      $("#ops-log").innerHTML = `<div class="empty">No recent activity.</div>`;
+      return;
+    }
+    const rows = items.slice(0, 50).map(l => `
+      <tr>
+        <td>${escapeHtml(l.timestamp || "")}</td>
+        <td>${escapeHtml(l.operation || "")}</td>
+        <td>${escapeHtml(l.entity_type || "")}</td>
+        <td class="id-cell" title="${escapeHtml(l.entity_id || "")}">${escapeHtml((l.entity_id || "").slice(0, 8))}</td>
+        <td class="context">${escapeHtml(l.context_note || "")}</td>
+      </tr>
+    `).join("");
+    $("#ops-log").innerHTML = `
+      <table class="ops-table">
+        <thead><tr>
+          <th>timestamp</th><th>operation</th><th>entity_type</th>
+          <th>entity</th><th>note</th>
+        </tr></thead>
+        <tbody>${rows}</tbody>
+      </table>
+    `;
+  } catch (e) {
+    console.error("loadLog failed:", e);
+    $("#ops-log").innerHTML = `<div class="empty">${escapeHtml(e.message)}</div>`;
+  }
+}
+
+async function loadRules() {
+  try {
+    const rules = await data.rules();
+    const items = rules.items || rules || [];
+    if (items.length === 0) {
+      $("#ops-rules").innerHTML = `<div class="empty">No always-on rules.</div>`;
+      return;
+    }
+    $("#ops-rules").innerHTML = items.map(r => `
+      <div class="rule-row">
+        <div class="rule-meta">${escapeHtml(r.category || "")} · priority ${r.priority != null ? r.priority : "?"}</div>
+        <div>${escapeHtml(r.content || "")}</div>
+      </div>
+    `).join("");
+  } catch (e) {
+    console.error("loadRules failed:", e);
+    $("#ops-rules").innerHTML = `<div class="empty">${escapeHtml(e.message)}</div>`;
+  }
+}
+
+// ============================================================
+// Ask drawer
+// ============================================================
+function initAsk() {
+  const drawer = $("#ask-drawer");
+  const form = $("#ask-form");
+  const input = $("#ask-input");
+  const submit = $("#ask-submit");
+  const status = $("#ask-status");
+  const out = $("#ask-output");
+
+  $("#ask-toggle").addEventListener("click", () => {
+    openDrawer(drawer);
+    input.focus();
+  });
+
+  form.addEventListener("submit", async (ev) => {
+    ev.preventDefault();
+    const q = input.value.trim();
+    if (!q) return;
+    submit.disabled = true;
+    out.innerHTML = "";
+
+    let elapsed = 0;
+    status.textContent = `Thinking… 0s`;
+    const t0 = Date.now();
+    const ticker = setInterval(() => {
+      elapsed = Math.round((Date.now() - t0) / 1000);
+      status.textContent = `Thinking… ${elapsed}s`;
+    }, 500);
+
+    try {
+      const res = await data.agent(q);
+      clearInterval(ticker);
+      status.textContent = `Done in ${Math.round((Date.now() - t0) / 1000)}s.`;
+      const answer = res.answer || JSON.stringify(res, null, 2);
+      const rendered = renderWiki(answer);
+      out.innerHTML = `<div class="wiki-content">${rendered.html}</div>`;
+      // Wire any ref chips in the answer
+      $$(".ref-chip", out).forEach(a => {
+        a.addEventListener("click", (e2) => {
+          e2.preventDefault();
+          openEntityDrawer(a.dataset.ref);
+        });
+      });
+    } catch (e) {
+      clearInterval(ticker);
+      status.textContent = "Error.";
+      out.innerHTML = `<div class="empty"><strong>Failed:</strong> <code>${escapeHtml(e.message)}</code></div>`;
+    } finally {
+      submit.disabled = false;
+    }
+  });
+}
+
+// ============================================================
+// Keyboard shortcuts
+// ============================================================
+function initKeys() {
+  document.addEventListener("keydown", (ev) => {
+    const tag = (ev.target.tagName || "").toLowerCase();
+    const inField = tag === "input" || tag === "textarea";
+
+    // Esc: close any drawer
+    if (ev.key === "Escape") {
+      closeDrawer($("#entity-drawer"));
+      closeDrawer($("#ask-drawer"));
+      return;
+    }
+    // Cmd/Ctrl+K: focus Ask
+    if ((ev.metaKey || ev.ctrlKey) && ev.key.toLowerCase() === "k") {
+      ev.preventDefault();
+      openDrawer($("#ask-drawer"));
+      $("#ask-input").focus();
+      return;
+    }
+    if (inField) return;
+    // / : focus search (Reader)
+    if (ev.key === "/") {
+      ev.preventDefault();
+      if (location.hash !== "#/ops") {
+        $("#search-input").focus();
+      }
+    }
+  });
+}
+
+// ============================================================
+// Boot
+// ============================================================
+async function boot() {
+  initTheme();
+  initTabs();
+  initDrawers();
+  initSearch();
+  initAsk();
+  initKeys();
+
+  // Initial data load: the wiki index is cheap and needed by Reader.
+  try {
+    await loadWikiIndex();
+  } catch (e) {
+    $("#wiki-index").innerHTML = `<li class="empty">Index failed: ${escapeHtml(e.message)}</li>`;
+  }
+
+  window.addEventListener("hashchange", handleRoute);
+  await handleRoute();
+}
+
+boot();

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -280,6 +280,17 @@ function renderRelations(relations) {
     return;
   }
 
+  // Dedupe by (relation_type, from, to) — DB can have duplicate edge rows
+  // (especially for tagged_with) from ingest race conditions; collapse them.
+  const seenKey = new Set();
+  const deduped = relations.filter(r => {
+    const k = `${r.relation_type}|${r.from_entity_id}|${r.to_entity_id}`;
+    if (seenKey.has(k)) return false;
+    seenKey.add(k);
+    return true;
+  });
+  relations = deduped;
+
   // Group by relation_type
   const groups = {};
   for (const r of relations) {
@@ -293,11 +304,15 @@ function renderRelations(relations) {
     h.textContent = `${type} (${rows.length})`;
     g.appendChild(h);
     for (const r of rows) {
+      const target = r.to_entity_id || r.from_entity_id;
       const row = document.createElement("div");
       row.className = "relation-row";
-      row.dataset.id = r.to_entity_id || r.from_entity_id;
+      row.dataset.id = target;
       row.innerHTML = `
-        <div>${escapeHtml(r.to_entity_label || r.from_entity_label || r.to_entity_id || r.from_entity_id)}</div>
+        <span class="entity-chip" data-resolve-id="${escapeHtml(target)}">
+          <span class="type-pill type-unknown">…</span>
+          <span class="entity-name">${escapeHtml((target || "").slice(0, 8))}</span>
+        </span>
         ${r.description ? `<span class="preview">${escapeHtml(r.description)}</span>` : ""}
       `;
       row.addEventListener("click", () => openEntityDrawer(row.dataset.id));
@@ -307,6 +322,7 @@ function renderRelations(relations) {
   }
 
   panel.hidden = false;
+  resolveAndPatch(body);
 }
 
 // ============================================================
@@ -328,9 +344,12 @@ async function openEntityDrawer(id) {
     return;
   }
 
+  const titleLabel = previewCanonicalName(entity.content)
+                  || entitySnippet(entity.content, entity.entity_type === "wiki").slice(0, 60)
+                  || id.slice(0, 8);
   title.textContent = entity.entity_type
-    ? `${entity.entity_type} · ${id.slice(0, 8)}`
-    : id.slice(0, 8);
+    ? `${entity.entity_type} · ${titleLabel}`
+    : titleLabel;
 
   const sourcePill = entity.source
     ? `<span class="pill">source: ${escapeHtml(entity.source)}</span>` : "";
@@ -340,20 +359,61 @@ async function openEntityDrawer(id) {
     ? `<span class="pill">importance: ${entity.importance}</span>` : "";
 
   const isWiki = entity.entity_type === "wiki";
+  const isDatasource = entity.entity_type === "datasource";
+  const isSource = entity.entity_type === "source";
   const rendered = renderWiki(entity.content || "");
   const contentHtml = isWiki
     ? `<div class="wiki-content">${rendered.html}</div>`
-    : `<pre>${escapeHtml(entity.content || "")}</pre>`;
+    : `<pre id="drawer-content-pre">${escapeHtml(entity.content || "")}</pre>`;
 
+  // Top action row: "Open full wiki" for wikis; external URL for source.
+  // file_path is NOT a clickable link — browsers block file:// from http://
+  // pages — instead it's rendered as copy-able text in the meta strip below.
+  const actions = [];
+  if (isWiki) {
+    actions.push(`<a class="drawer-action" href="#/wiki/${id}" data-close-drawer="entity">Open full wiki →</a>`);
+  }
+  if ((isSource || isDatasource) && entity.url) {
+    actions.push(`<a class="drawer-action" href="${escapeHtml(entity.url)}" target="_blank" rel="noopener">Open URL ↗</a>`);
+  }
+  const actionsRow = actions.length ? `<div class="drawer-actions-row">${actions.join("")}</div>` : "";
+
+  // For datasources / sources with a local file_path, show it as copy-able text
+  // (no broken file:// link).
+  const filePathRow = ((isSource || isDatasource) && entity.file_path)
+    ? `<div class="entity-filepath" title="Local file path — copy and open in your file manager"><span class="filepath-label">File:</span> <code>${escapeHtml(entity.file_path)}</code></div>`
+    : "";
+
+  // Pagination hint for big bodies (datasources especially)
+  const meta = entity.content_meta || {};
+  const hasMore = meta.next_offset != null;
+  const loadMoreRow = hasMore
+    ? `<button id="drawer-load-more" class="drawer-action secondary" data-next-offset="${meta.next_offset}">Load more (chunk ${meta.chunk_index + 1 || "?"}) ↓</button>`
+    : "";
+
+  // Dedupe relations by (relation_type, opposite endpoint) — backend or
+  // earlier ingest bug can produce duplicate rows; show each pair once.
   let relationsHtml = "";
   if (relations && relations.length) {
+    const seenKey = new Set();
+    const deduped = relations.filter(r => {
+      const opp = r.to_entity_id === id ? r.from_entity_id : r.to_entity_id;
+      const k = `${r.relation_type}|${opp}`;
+      if (seenKey.has(k)) return false;
+      seenKey.add(k);
+      return true;
+    });
     const groups = {};
-    for (const r of relations) (groups[r.relation_type] ||= []).push(r);
+    for (const r of deduped) (groups[r.relation_type] ||= []).push(r);
     const groupHtml = Object.entries(groups).sort().map(([type, rows]) => {
       const items = rows.map(r => {
-        const target = r.to_entity_id || r.from_entity_id;
-        const label = r.to_entity_label || r.from_entity_label || target;
-        return `<div class="relation-row" data-id="${target}"><div>${escapeHtml(label)}</div></div>`;
+        const target = r.to_entity_id === id ? r.from_entity_id : r.to_entity_id;
+        return `<div class="relation-row" data-id="${target}">
+          <span class="entity-chip" data-resolve-id="${escapeHtml(target)}">
+            <span class="type-pill type-unknown">…</span>
+            <span class="entity-name">${escapeHtml((target || "").slice(0, 8))}</span>
+          </span>
+        </div>`;
       }).join("");
       return `<div class="relations-group"><h4>${type} (${rows.length})</h4>${items}</div>`;
     }).join("");
@@ -361,13 +421,50 @@ async function openEntityDrawer(id) {
   }
 
   body.innerHTML = `
+    ${actionsRow}
     <div class="entity-meta">${sourcePill}${certPill}${impPill}</div>
+    ${filePathRow}
     <div class="entity-section">
       <h4>Content</h4>
       ${contentHtml}
+      ${loadMoreRow}
     </div>
     ${relationsHtml}
   `;
+
+  // Resolve all chip placeholders inside the drawer (relations block)
+  resolveAndPatch(body);
+
+  // Wire "Open full wiki" / external link to also close the drawer cleanly
+  $$('.drawer-action[data-close-drawer]', body).forEach(a => {
+    a.addEventListener("click", () => closeDrawer($("#entity-drawer")));
+  });
+
+  // Wire "Load more" pagination for big bodies
+  const loadMoreBtn = $("#drawer-load-more", body);
+  if (loadMoreBtn) {
+    loadMoreBtn.addEventListener("click", async () => {
+      loadMoreBtn.disabled = true;
+      loadMoreBtn.textContent = "Loading…";
+      try {
+        const offset = parseInt(loadMoreBtn.dataset.nextOffset, 10);
+        const next = await apiGet(`/entities/${id}?offset=${offset}&limit=4000`);
+        const pre = $("#drawer-content-pre", body);
+        if (pre) pre.textContent += next.content || "";
+        // Update / remove button based on next.content_meta.next_offset
+        const nm = next.content_meta || {};
+        if (nm.next_offset != null) {
+          loadMoreBtn.dataset.nextOffset = nm.next_offset;
+          loadMoreBtn.textContent = `Load more (chunk ${(nm.chunk_index || 0) + 1}) ↓`;
+          loadMoreBtn.disabled = false;
+        } else {
+          loadMoreBtn.remove();
+        }
+      } catch (e) {
+        loadMoreBtn.textContent = `Failed: ${e.message}`;
+      }
+    });
+  }
 
   // Drill-down: clicking a relation in the drawer swaps the drawer to that entity
   $$(".relation-row", body).forEach(row => {
@@ -522,6 +619,8 @@ async function openGraph(seedId) {
 
 function initGraph() {
   // Toolbar buttons
+  $("#graph-zoom-in").addEventListener("click", () => graph.zoomIn());
+  $("#graph-zoom-out").addEventListener("click", () => graph.zoomOut());
   $("#graph-fit").addEventListener("click", () => graph.fit());
   $("#graph-reset").addEventListener("click", () => {
     graph.reset();
@@ -551,9 +650,18 @@ function initGraph() {
         const id = it.id || it.entity_id;
         const type = it.entity_type || "?";
         const label = (previewCanonicalName(it.content) || (it.content || "").split("\n")[0] || id).slice(0, 60);
+
+        // Only wikis carry a retired flag. wikiIndexCache (loaded at app
+        // boot) has retired_at for every wiki — reuse it.
+        let retiredTag = "";
+        if (type === "wiki" && wikiIndexCache) {
+          const w = wikiIndexCache.find(x => x.id === id);
+          if (w && w.retired_at) retiredTag = ` <span class="retired-tag">retired</span>`;
+        }
+
         const row = document.createElement("div");
         row.className = "result-item";
-        row.innerHTML = `<span class="result-type">${escapeHtml(type)}</span> ${escapeHtml(label)}`;
+        row.innerHTML = `<span class="result-type">${escapeHtml(type)}</span> ${escapeHtml(label)}${retiredTag}`;
         row.addEventListener("click", async () => {
           results.hidden = true;
           input.value = "";
@@ -625,6 +733,12 @@ async function loadStats() {
   }
 }
 
+function actorOf(jobType) {
+  if (jobType === "triage") return "MAINTAINER";
+  if (jobType === "attach" || jobType === "create" || jobType === "consolidate") return "WRITER";
+  return "SCHEDULER";
+}
+
 async function loadJobs() {
   try {
     const jobs = await data.jobs();
@@ -634,33 +748,121 @@ async function loadJobs() {
       return;
     }
     const rows = items.slice(0, 100).map(j => {
-      const cls = (j.status === "pending" && j.job_type === "consolidate")
-        ? "highlight-consolidate" : "";
+      const classes = [];
+      if (j.status === "pending" && j.job_type === "consolidate") classes.push("highlight-consolidate");
+      if (j.status === "failed") classes.push("row-failed");
+      // The wiki_job table has TWO note columns: `rationale` (LLM's reasoning,
+      // benign) and `last_error` (real errors). Show whichever is set; only
+      // colour as an error when status='failed' AND we actually have a
+      // last_error message.
+      const note = j.rationale || j.last_error || "";
+      const isRealError = j.status === "failed" && j.last_error;
+      const actor = actorOf(j.job_type);
+      const firstEntity = (j.entity_ids && j.entity_ids[0]) || "";
+
+      const chip = (id) => id
+        ? `<span class="entity-chip" data-resolve-id="${escapeHtml(id)}">
+             <span class="type-pill type-unknown">…</span>
+             <span class="entity-name">${escapeHtml(id.slice(0, 8))}</span>
+           </span>`
+        : `<span class="ink-muted">—</span>`;
+
       return `
-        <tr class="${cls}">
-          <td class="id-cell" title="${escapeHtml(j.id)}">${escapeHtml((j.id || "").slice(0, 8))}</td>
+        <tr class="${classes.join(" ")}" title="job ${escapeHtml(j.id)} · attempts ${j.attempts ?? 0}">
+          <td><span class="actor-pill actor-${actor.toLowerCase()}">${actor}</span></td>
           <td>${escapeHtml(j.job_type || "")}</td>
           <td>${escapeHtml(j.status || "")}</td>
-          <td class="id-cell">${escapeHtml((j.target_wiki_id || "").slice(0, 8))}</td>
-          <td>${escapeHtml(j.created_at || "")}</td>
-          <td>${j.attempts != null ? j.attempts : ""}</td>
-          <td class="context">${escapeHtml(j.last_error || "")}</td>
+          <td>${chip(j.target_wiki_id)}</td>
+          <td>${chip(firstEntity)}</td>
+          <td>${escapeHtml((j.created_at || "").slice(0, 19))}</td>
+          <td class="context ${isRealError ? "context-error" : ""}">${escapeHtml(note)}</td>
         </tr>
       `;
     }).join("");
     $("#ops-jobs").innerHTML = `
       <table class="ops-table">
         <thead><tr>
-          <th>id</th><th>type</th><th>status</th><th>target</th>
-          <th>created</th><th>tries</th><th>last_error</th>
+          <th>actor</th><th>action</th><th>status</th><th>target wiki</th>
+          <th>entity</th><th>created</th><th>note</th>
         </tr></thead>
         <tbody>${rows}</tbody>
       </table>
     `;
+    resolveAndPatch($("#ops-jobs"));
   } catch (e) {
     console.error("loadJobs failed:", e);
     $("#ops-jobs").innerHTML = `<div class="empty">${escapeHtml(e.message)}</div>`;
   }
+}
+
+// ============================================================
+// Universal entity resolver — no raw UUIDs anywhere in the UI.
+// ============================================================
+// Caches the full entity object by id so renderers can reach for type +
+// canonical name + preview without round-tripping the API every time.
+const entityCache = new Map();
+const entityInflight = new Map();          // id → Promise (dedupe concurrent fetches)
+
+async function resolveEntity(id) {
+  if (!id) return null;
+  if (entityCache.has(id)) return entityCache.get(id);
+  if (entityInflight.has(id)) return entityInflight.get(id);
+  // Fast path: wikiIndexCache (loaded once at boot, covers all wikis).
+  if (wikiIndexCache) {
+    const w = wikiIndexCache.find(x => x.id === id);
+    if (w) { entityCache.set(id, w); return w; }
+  }
+  const p = data.entity(id).then(e => {
+    entityCache.set(id, e || null);
+    entityInflight.delete(id);
+    return e;
+  }).catch(() => {
+    entityCache.set(id, null);
+    entityInflight.delete(id);
+    return null;
+  });
+  entityInflight.set(id, p);
+  return p;
+}
+
+// HTML for a resolved entity chip: small type-pill + canonical-name / snippet.
+// Falls back to short-UUID if the entity hasn't resolved yet.
+function entityChipHtml(entity, idFallback = "") {
+  if (!entity) {
+    return `<span class="entity-chip"><span class="type-pill type-unknown">?</span><span class="entity-name">${escapeHtml((idFallback || "").slice(0, 8))}</span></span>`;
+  }
+  const t = entity.entity_type || "?";
+  const isWiki = t === "wiki";
+  const label = previewCanonicalName(entity.content)
+              || entitySnippet(entity.content, isWiki).slice(0, 60)
+              || (entity.id || "").slice(0, 8);
+  return `<span class="entity-chip" title="${escapeHtml(entity.id)}"><span class="type-pill type-${escapeHtml(t)}">${escapeHtml(t)}</span><span class="entity-name">${escapeHtml(label)}</span></span>`;
+}
+
+// After rendering a section that contains placeholder chips (elements with
+// `data-resolve-id`), batch-fetch all the IDs and patch each chip in-place.
+// Uses cached entities when available — first paint is the only one that hits
+// the network.
+async function resolveAndPatch(root) {
+  if (!root) return;
+  const slots = $$(".entity-chip[data-resolve-id]", root);
+  const ids = [...new Set(slots.map(s => s.dataset.resolveId).filter(Boolean))];
+  if (ids.length === 0) return;
+  await Promise.all(ids.map(id => resolveEntity(id)));
+  slots.forEach(s => {
+    const id = s.dataset.resolveId;
+    const e = entityCache.get(id);
+    if (e) s.outerHTML = entityChipHtml(e, id);
+  });
+}
+
+function logActorOf(operation) {
+  const op = (operation || "").toLowerCase();
+  if (op.startsWith("wiki_maintain") || op.includes("triage")) return "MAINTAINER";
+  if (op.startsWith("wiki_write") || op.includes("attach") || op.includes("create") || op.includes("consolidate")) return "WRITER";
+  if (op.startsWith("wiki_cron") || op.includes("schedule")) return "SCHEDULER";
+  if (op.startsWith("ingest") || op.includes("watch")) return "WATCHER";
+  return "SYSTEM";
 }
 
 async function loadLog() {
@@ -671,24 +873,33 @@ async function loadLog() {
       $("#ops-log").innerHTML = `<div class="empty">No recent activity.</div>`;
       return;
     }
-    const rows = items.slice(0, 50).map(l => `
-      <tr>
-        <td>${escapeHtml(l.timestamp || "")}</td>
-        <td>${escapeHtml(l.operation || "")}</td>
-        <td>${escapeHtml(l.entity_type || "")}</td>
-        <td class="id-cell" title="${escapeHtml(l.entity_id || "")}">${escapeHtml((l.entity_id || "").slice(0, 8))}</td>
-        <td class="context">${escapeHtml(l.context_note || "")}</td>
-      </tr>
-    `).join("");
+    const rows = items.slice(0, 50).map(l => {
+      const actor = logActorOf(l.operation);
+      const entityCell = l.entity_id
+        ? `<span class="entity-chip" data-resolve-id="${escapeHtml(l.entity_id)}">
+             <span class="type-pill type-unknown">…</span>
+             <span class="entity-name">${escapeHtml(l.entity_id.slice(0, 8))}</span>
+           </span>`
+        : `<span class="ink-muted">—</span>`;
+      return `
+        <tr>
+          <td>${escapeHtml((l.timestamp || "").slice(0, 19))}</td>
+          <td><span class="actor-pill actor-${actor.toLowerCase()}">${actor}</span></td>
+          <td>${escapeHtml(l.operation || "")}</td>
+          <td>${entityCell}</td>
+          <td class="context">${escapeHtml(l.context_note || "")}</td>
+        </tr>
+      `;
+    }).join("");
     $("#ops-log").innerHTML = `
       <table class="ops-table">
         <thead><tr>
-          <th>timestamp</th><th>operation</th><th>entity_type</th>
-          <th>entity</th><th>note</th>
+          <th>when</th><th>actor</th><th>operation</th><th>entity</th><th>note</th>
         </tr></thead>
         <tbody>${rows}</tbody>
       </table>
     `;
+    resolveAndPatch($("#ops-log"));
   } catch (e) {
     console.error("loadLog failed:", e);
     $("#ops-log").innerHTML = `<div class="empty">${escapeHtml(e.message)}</div>`;

--- a/frontend/graph.js
+++ b/frontend/graph.js
@@ -1,0 +1,416 @@
+// ============================================================
+// graph.js — vis-network powered graph view of BrainDB entities.
+//   - Different shapes / colours per entity_type.
+//   - Edge labels hidden by default, revealed on hover / select.
+//   - Soft cap of 300 nodes.
+//   - Hidden-container mount handled via IntersectionObserver +
+//     network.setSize() so the graph centres correctly once visible.
+//
+// Depends on `window.vis` from the vis-network CDN script tag in
+// index.html. All other modules call this through the public API
+// below — graph.ensureMounted / seed / searchSeeds / clear / fit /
+// reset / toggleKeywords / refreshStyle.
+// ============================================================
+
+const API = (window.BRAINDB_API_URL || "http://localhost:8000") + "/api/v1";
+
+// ------------------------------------------------------------
+// Self-contained fetch wrappers
+// ------------------------------------------------------------
+async function apiGet(path) {
+  const r = await fetch(API + path);
+  if (!r.ok) throw new Error(`HTTP ${r.status} on ${path}`);
+  return r.json();
+}
+async function apiPost(path, body) {
+  const r = await fetch(API + path, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (!r.ok) throw new Error(`HTTP ${r.status} on ${path}`);
+  return r.json();
+}
+
+// ------------------------------------------------------------
+// Per-session state
+// ------------------------------------------------------------
+let network = null;
+let nodesDS = null;
+let edgesDS = null;
+const inFlight = new Set();         // entity IDs currently being expanded
+let onClickCb = null;
+const HARD_CAP = 300;
+
+// ------------------------------------------------------------
+// Theme tokens
+// ------------------------------------------------------------
+function cssVar(name) {
+  return getComputedStyle(document.documentElement).getPropertyValue(name).trim();
+}
+
+function colours() {
+  return {
+    ink: cssVar("--ink") || "#1b1b1b",
+    inkSoft: cssVar("--ink-soft") || "#4a4a4a",
+    inkMuted: cssVar("--ink-muted") || "#8a8a8a",
+    paper: cssVar("--paper") || "#fff",
+    paperSoft: cssVar("--paper-soft") || "#f8f8f7",
+    rule: cssVar("--rule") || "#eaeaea",
+    accent: cssVar("--accent") || "#0645ad",
+    amber: "#b86c00",
+    teal: "#226666",
+    rule_: "#7a4a8a",
+  };
+}
+
+// ------------------------------------------------------------
+// Entity → vis-network node config
+// ------------------------------------------------------------
+function nodeConfig(entity) {
+  const c = colours();
+  const t = entity.entity_type;
+  const label = entityLabel(entity);
+  const base = {
+    id: entity.id,
+    label,
+    title: label,              // hover tooltip
+    entity_type: t,            // custom field, used by toggleKeywords
+    font: { size: 11, color: c.ink, face: "-apple-system, system-ui, sans-serif" },
+    borderWidth: 1,
+  };
+  switch (t) {
+    case "wiki":
+      return { ...base, shape: "box", color: { background: c.accent, border: c.accent },
+        font: { ...base.font, color: c.paper, vadjust: 0 },
+        shapeProperties: { borderRadius: 6 },
+        widthConstraint: { maximum: 110 },
+        margin: 6 };
+    case "fact":
+      return { ...base, shape: "ellipse",
+        color: { background: c.paperSoft, border: c.inkSoft },
+        widthConstraint: { maximum: 110 } };
+    case "thought":
+      return { ...base, shape: "ellipse",
+        color: { background: c.paperSoft, border: c.inkMuted },
+        shapeProperties: { borderDashes: [4, 2] },
+        widthConstraint: { maximum: 110 } };
+    case "keyword":
+      // Diamond/dot/database etc. all place their label BELOW the shape,
+      // so the label needs ink colour to be readable on the paper background.
+      return { ...base, shape: "diamond",
+        color: { background: c.amber, border: c.amber },
+        font: { ...base.font, color: c.inkSoft },
+        size: 10 };
+    case "source":
+    case "datasource":
+      return { ...base, shape: "database",
+        color: { background: c.teal, border: c.teal },
+        font: { ...base.font, color: c.inkSoft } };
+    case "rule":
+      // `box` shape contains its label INSIDE, so white-on-purple is fine.
+      return { ...base, shape: "box",
+        color: { background: c.rule_, border: c.rule_ },
+        font: { ...base.font, color: c.paper },
+        shapeProperties: { borderRadius: 6 } };
+    default:
+      return { ...base, shape: "dot", size: 8,
+        color: { background: c.paperSoft, border: c.inkSoft } };
+  }
+}
+
+function edgeConfig(rel) {
+  const c = colours();
+  const id = rel.id || `${rel.from_entity_id}__${rel.relation_type}__${rel.to_entity_id}`;
+  let color = c.inkMuted;
+  if (rel.relation_type === "summarises") color = c.accent;
+  else if (rel.relation_type === "tagged_with") color = c.amber;
+  else if (rel.relation_type === "derived_from") color = c.teal;
+  else if (rel.relation_type === "consolidates") color = c.rule_;
+  return {
+    id,
+    from: rel.from_entity_id,
+    to: rel.to_entity_id,
+    relation_type: rel.relation_type,
+    arrows: { to: { enabled: true, scaleFactor: 0.5 } },
+    color: { color, opacity: 0.5 },
+    width: 1,
+    smooth: { enabled: true, type: "dynamic", roundness: 0.3 },
+    font: { size: 0, align: "middle" },   // hidden by default
+  };
+}
+
+function entityLabel(entity) {
+  if (!entity) return "?";
+  const idShort = (entity.id || "").slice(0, 6);
+  if (entity.entity_type === "wiki") {
+    const h = (entity.content || "").match(/^#\s+(.+)$/m);
+    if (h) return truncate(h[1].trim(), 24);
+    const m = (entity.content || "").match(/canonical_name=(?:"([^"]+)"|([^\s][^>]*?))(?=\s+\w+=|\s*-->|$)/);
+    if (m) return truncate((m[1] || m[2] || "").trim(), 24);
+    return idShort;
+  }
+  if (entity.entity_type === "keyword") {
+    const k = (entity.content || "").trim();
+    return k ? truncate(k, 20) : idShort;
+  }
+  const c = (entity.title || entity.content || "").toString().trim();
+  if (c) return truncate(c.split(/\r?\n/)[0], 24);
+  return idShort;
+}
+
+function truncate(s, n) {
+  if (!s) return "";
+  return s.length > n ? s.slice(0, n - 1) + "…" : s;
+}
+
+// ------------------------------------------------------------
+// Public API
+// ------------------------------------------------------------
+export function isInitialised() {
+  return network !== null;
+}
+
+export function ensureMounted(container, onNodeClick) {
+  if (network) return network;
+
+  if (typeof window.vis === "undefined" || !window.vis.Network) {
+    container.innerHTML = `<div class="graph-empty">Graph library failed to load (vis-network unavailable). Check the CDN script in index.html.</div>`;
+    return null;
+  }
+
+  onClickCb = onNodeClick;
+
+  nodesDS = new window.vis.DataSet([]);
+  edgesDS = new window.vis.DataSet([]);
+
+  const options = {
+    autoResize: true,
+    nodes: {
+      // sensible default; per-node overrides supplied in nodeConfig()
+      borderWidth: 1,
+      borderWidthSelected: 3,
+      scaling: { label: { enabled: false } },
+    },
+    edges: {
+      color: { inherit: false },
+      smooth: { enabled: true, type: "dynamic" },
+      hoverWidth: 0,
+      selectionWidth: 0,
+    },
+    physics: {
+      enabled: true,
+      barnesHut: {
+        gravitationalConstant: -8000,
+        centralGravity: 0.05,
+        springLength: 130,
+        springConstant: 0.04,
+        damping: 0.6,
+        avoidOverlap: 0.5,
+      },
+      stabilization: {
+        enabled: true,
+        iterations: 250,
+        updateInterval: 25,
+        fit: true,                 // <-- vis-network's own auto-fit after settle
+      },
+    },
+    interaction: {
+      hover: true,
+      hoverConnectedEdges: true,
+      zoomView: true,
+      dragView: true,
+      tooltipDelay: 250,
+      multiselect: false,
+    },
+    layout: {
+      improvedLayout: true,
+    },
+  };
+
+  network = new window.vis.Network(container, { nodes: nodesDS, edges: edgesDS }, options);
+
+  // Click → drawer
+  network.on("click", (params) => {
+    if (params.nodes && params.nodes[0] && onClickCb) onClickCb(params.nodes[0]);
+  });
+
+  // Double-click → expand neighbourhood
+  network.on("doubleClick", async (params) => {
+    if (params.nodes && params.nodes[0]) {
+      await expandNode(params.nodes[0]);
+    }
+  });
+
+  // Hover an edge → reveal its label
+  network.on("hoverEdge", (params) => {
+    edgesDS.update({ id: params.edge, font: { size: 10, color: colours().inkSoft, strokeWidth: 3, strokeColor: colours().paper } });
+  });
+  network.on("blurEdge", (params) => {
+    edgesDS.update({ id: params.edge, font: { size: 0 } });
+  });
+
+  // Selecting a node → reveal incident edges' labels
+  network.on("selectNode", (params) => {
+    const nid = params.nodes[0];
+    if (!nid) return;
+    const incident = network.getConnectedEdges(nid);
+    const updates = incident.map(eid => ({ id: eid, font: { size: 10, color: colours().inkSoft, strokeWidth: 3, strokeColor: colours().paper } }));
+    edgesDS.update(updates);
+  });
+  network.on("deselectNode", () => {
+    const updates = edgesDS.getIds().map(eid => ({ id: eid, font: { size: 0 } }));
+    edgesDS.update(updates);
+  });
+
+  // Once the layout settles, fit explicitly (belt-and-braces; physics.stabilization.fit=true also does it).
+  network.on("stabilized", () => {
+    network.fit({ animation: { duration: 250, easingFunction: "easeInOutQuad" } });
+  });
+
+  // Hidden-container handling: if the canvas wasn't visible at mount, fit
+  // again once it appears. IntersectionObserver fires when the container
+  // gets non-zero dimensions.
+  if (typeof IntersectionObserver !== "undefined") {
+    const io = new IntersectionObserver((entries) => {
+      for (const e of entries) {
+        if (e.isIntersecting && e.target.clientWidth > 10) {
+          network.setSize(e.target.clientWidth + "px", e.target.clientHeight + "px");
+          network.redraw();
+          network.fit({ animation: false });
+        }
+      }
+    });
+    io.observe(container);
+  }
+
+  // Window resize → refit
+  window.addEventListener("resize", () => {
+    if (network) network.redraw();
+  });
+
+  return network;
+}
+
+export async function seed(entityId, onStatus) {
+  if (!network) return;
+  onStatus?.("Loading…");
+  try {
+    const entity = await apiGet(`/entities/${entityId}`);
+    addOrUpdateNode(entity);
+    await expandNode(entityId, /*silent=*/true);
+    onStatus?.("");
+  } catch (e) {
+    console.error("graph.seed failed:", e);
+    onStatus?.(`Seed failed: ${e.message}`);
+  }
+}
+
+export async function searchSeeds(query) {
+  if (!query.trim()) return [];
+  const res = await apiPost("/memory/context", { queries: [query], max_depth: 1, max_results: 12 });
+  return res.items || [];
+}
+
+export function clear() {
+  if (!network) return;
+  nodesDS.clear();
+  edgesDS.clear();
+}
+
+export function fit() {
+  if (network) network.fit({ animation: { duration: 250 } });
+}
+
+export function reset() {
+  clear();
+}
+
+export function toggleKeywords(hide) {
+  if (!nodesDS) return;
+  const updates = nodesDS.get({
+    filter: n => n.entity_type === "keyword",
+  }).map(n => ({ id: n.id, hidden: !!hide }));
+  nodesDS.update(updates);
+}
+
+export function refreshStyle() {
+  if (!nodesDS) return;
+  // Re-apply colours from CSS variables for every node + edge (theme change).
+  const nodeUpdates = nodesDS.get().map(n => {
+    // Reconstitute config from stored entity_type + label
+    const cfg = nodeConfig({ id: n.id, entity_type: n.entity_type, content: n.label, title: n.label });
+    return { id: n.id, color: cfg.color, font: cfg.font, shapeProperties: cfg.shapeProperties };
+  });
+  nodesDS.update(nodeUpdates);
+}
+
+// ------------------------------------------------------------
+// Internals
+// ------------------------------------------------------------
+function addOrUpdateNode(entity) {
+  if (!nodesDS) return null;
+  const existing = nodesDS.get(entity.id);
+  const cfg = nodeConfig(entity);
+  if (existing) {
+    nodesDS.update(cfg);
+    return cfg;
+  }
+  if (nodesDS.length >= HARD_CAP) return null;
+  nodesDS.add(cfg);
+  return cfg;
+}
+
+function addOrUpdateEdge(rel) {
+  if (!edgesDS) return null;
+  const cfg = edgeConfig(rel);
+  if (edgesDS.get(cfg.id)) return cfg;
+  // Both endpoints must already be in the graph for the edge to render.
+  if (!nodesDS.get(rel.from_entity_id) || !nodesDS.get(rel.to_entity_id)) return null;
+  edgesDS.add(cfg);
+  return cfg;
+}
+
+async function expandNode(entityId, silent = false) {
+  if (!network) return;
+  if (inFlight.has(entityId)) return;
+  inFlight.add(entityId);
+  try {
+    const relations = await apiGet(`/entities/${entityId}/relations`);
+    const ids = new Set();
+    for (const r of relations) {
+      ids.add(r.from_entity_id);
+      ids.add(r.to_entity_id);
+    }
+    ids.delete(entityId);
+    const missing = [...ids].filter(id => !nodesDS.get(id));
+    if (nodesDS.length + missing.length > HARD_CAP) {
+      if (!silent) flashToast(`Graph capped at ${HARD_CAP} nodes; prune before expanding more.`);
+    } else {
+      const fetched = await Promise.all(missing.map(async id => {
+        try { return await apiGet(`/entities/${id}`); } catch { return null; }
+      }));
+      for (const e of fetched) if (e) addOrUpdateNode(e);
+    }
+    for (const r of relations) addOrUpdateEdge(r);
+  } catch (e) {
+    console.error(`expandNode(${entityId}) failed:`, e);
+    if (!silent) flashToast(`Expand failed: ${e.message}`);
+  } finally {
+    inFlight.delete(entityId);
+  }
+}
+
+// Small toast for non-blocking status (cap message etc.)
+let toastEl = null;
+function flashToast(msg) {
+  if (!toastEl) {
+    toastEl = document.createElement("div");
+    toastEl.className = "graph-toast";
+    document.body.appendChild(toastEl);
+  }
+  toastEl.textContent = msg;
+  toastEl.classList.add("show");
+  clearTimeout(toastEl._t);
+  toastEl._t = setTimeout(() => toastEl.classList.remove("show"), 3200);
+}

--- a/frontend/graph.js
+++ b/frontend/graph.js
@@ -104,9 +104,15 @@ function nodeConfig(entity) {
         size: 10 };
     case "source":
     case "datasource":
+      // vis-network's `database` shape puts the label INSIDE and ignores
+      // `size`; constrain width + shrink font so the cylinder stays small
+      // regardless of how long the label is.
       return { ...base, shape: "database",
         color: { background: c.teal, border: c.teal },
-        font: { ...base.font, color: c.inkSoft } };
+        font: { ...base.font, color: c.paper, size: 9 },
+        widthConstraint: { maximum: 70 },
+        heightConstraint: { minimum: 18 },
+        margin: 4 };
     case "rule":
       // `box` shape contains its label INSIDE, so white-on-purple is fine.
       return { ...base, shape: "box",
@@ -212,16 +218,19 @@ export function ensureMounted(container, onNodeClick) {
         enabled: true,
         iterations: 250,
         updateInterval: 25,
-        fit: true,                 // <-- vis-network's own auto-fit after settle
+        fit: false,                // we do a one-shot fit in the stabilized handler
       },
     },
     interaction: {
       hover: true,
       hoverConnectedEdges: true,
-      zoomView: true,
-      dragView: true,
+      zoomView: true,         // scroll-wheel zoom
+      dragView: true,         // drag empty space to pan
+      dragNodes: true,        // drag a node to reposition it
       tooltipDelay: 250,
       multiselect: false,
+      navigationButtons: false,
+      keyboard: false,
     },
     layout: {
       improvedLayout: true,
@@ -230,12 +239,18 @@ export function ensureMounted(container, onNodeClick) {
 
   network = new window.vis.Network(container, { nodes: nodesDS, edges: edgesDS }, options);
 
-  // Click → drawer
+  // Click on a node → BOTH open drawer AND auto-expand its 1-hop
+  // neighbourhood (silent, idempotent). Matches the seed-add UX where
+  // a freshly seeded node arrives with its connections already drawn.
   network.on("click", (params) => {
-    if (params.nodes && params.nodes[0] && onClickCb) onClickCb(params.nodes[0]);
+    const id = params.nodes && params.nodes[0];
+    if (!id) return;
+    if (onClickCb) onClickCb(id);
+    expandNode(id, /*silent=*/true);
   });
 
-  // Double-click → expand neighbourhood
+  // Double-click → explicit re-expand (no-op if already expanded; useful
+  // to force a refit after the layout settled or after pruning).
   network.on("doubleClick", async (params) => {
     if (params.nodes && params.nodes[0]) {
       await expandNode(params.nodes[0]);
@@ -263,9 +278,17 @@ export function ensureMounted(container, onNodeClick) {
     edgesDS.update(updates);
   });
 
-  // Once the layout settles, fit explicitly (belt-and-braces; physics.stabilization.fit=true also does it).
+  // Once the layout settles, fit ONCE (first stabilization only) and turn off
+  // physics permanently. New nodes added via expandNode() get deterministic
+  // ring positions — physics never wakes up again, so the camera stays put and
+  // the graph never drifts under the user's mouse.
+  let firstStabilizedDone = false;
   network.on("stabilized", () => {
-    network.fit({ animation: { duration: 250, easingFunction: "easeInOutQuad" } });
+    if (!firstStabilizedDone) {
+      network.fit({ animation: { duration: 250, easingFunction: "easeInOutQuad" } });
+      firstStabilizedDone = true;
+    }
+    network.setOptions({ physics: { enabled: false } });
   });
 
   // Hidden-container handling: if the canvas wasn't visible at mount, fit
@@ -320,6 +343,20 @@ export function clear() {
 
 export function fit() {
   if (network) network.fit({ animation: { duration: 250 } });
+}
+
+export function zoomIn() {
+  if (!network) return;
+  network.moveTo({ scale: network.getScale() * 1.3, animation: { duration: 200 } });
+}
+
+export function zoomOut() {
+  if (!network) return;
+  network.moveTo({ scale: network.getScale() * 0.7, animation: { duration: 200 } });
+}
+
+export async function expand(id) {
+  return expandNode(id);
 }
 
 export function reset() {
@@ -384,15 +421,39 @@ async function expandNode(entityId, silent = false) {
     }
     ids.delete(entityId);
     const missing = [...ids].filter(id => !nodesDS.get(id));
+
     if (nodesDS.length + missing.length > HARD_CAP) {
       if (!silent) flashToast(`Graph capped at ${HARD_CAP} nodes; prune before expanding more.`);
-    } else {
+    } else if (missing.length > 0) {
+      // Where are we expanding FROM? Use the seed node's current canvas
+      // position so new nodes appear in a ring AROUND it, not at (0,0).
+      const positions = network.getPositions([entityId]);
+      const center = positions[entityId] || { x: 0, y: 0 };
+      const radius = 180 + Math.random() * 40;     // 180-220 px ring
+
       const fetched = await Promise.all(missing.map(async id => {
         try { return await apiGet(`/entities/${id}`); } catch { return null; }
       }));
-      for (const e of fetched) if (e) addOrUpdateNode(e);
+      const valid = fetched.filter(Boolean);
+      const angleStep = valid.length > 0 ? (2 * Math.PI) / valid.length : 0;
+      // Random rotation so successive expansions don't all start at angle 0.
+      const angleOffset = Math.random() * Math.PI * 2;
+
+      valid.forEach((e, i) => {
+        const cfg = nodeConfig(e);
+        if (nodesDS.length >= HARD_CAP) return;
+        if (nodesDS.get(cfg.id)) { nodesDS.update(cfg); return; }
+        const angle = angleOffset + i * angleStep + (Math.random() - 0.5) * 0.4;
+        cfg.x = center.x + radius * Math.cos(angle);
+        cfg.y = center.y + radius * Math.sin(angle);
+        nodesDS.add(cfg);
+      });
     }
-    for (const r of relations) addOrUpdateEdge(r);
+    for (const r of relations) {
+      addOrUpdateEdge(r);
+    }
+    // No physics re-enable: new nodes have deterministic positions and the
+    // existing nodes don't move. Camera stays put, pan stays smooth.
   } catch (e) {
     console.error(`expandNode(${entityId}) failed:`, e);
     if (!silent) flashToast(`Expand failed: ${e.message}`);

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,108 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>BrainDB</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <header class="top">
+    <div class="brand">BrainDB</div>
+    <nav class="tabs" role="tablist">
+      <button class="tab is-active" data-tab="reader" role="tab">Reader</button>
+      <button class="tab" data-tab="ops" role="tab">Ops</button>
+    </nav>
+    <div class="top-actions">
+      <button id="ask-toggle" class="ask-button" title="Ask BrainDB (Ctrl/Cmd+K)">Ask</button>
+      <button id="theme-toggle" class="theme-toggle" title="Toggle theme">◐</button>
+    </div>
+  </header>
+
+  <main>
+    <!-- ============== READER ============== -->
+    <section id="reader" class="view is-active" role="tabpanel">
+      <aside class="rail">
+        <form id="search-form" class="search">
+          <input id="search-input" type="search" placeholder="Search (/ to focus)" autocomplete="off" />
+        </form>
+        <div id="search-results" class="results" hidden></div>
+        <div class="rail-section-label">Wikis</div>
+        <ul id="wiki-index" class="wiki-index"></ul>
+      </aside>
+
+      <article id="wiki-view" class="wiki-view">
+        <div class="empty">Select a wiki from the left.</div>
+      </article>
+
+      <aside id="relations-panel" class="relations" hidden>
+        <div class="rail-section-label">Relations</div>
+        <div id="relations-body"></div>
+      </aside>
+    </section>
+
+    <!-- ============== OPS ============== -->
+    <section id="ops" class="view" role="tabpanel" hidden>
+      <div class="ops-grid">
+        <div class="ops-block">
+          <div class="rail-section-label">Stats</div>
+          <div id="ops-stats" class="stats-strip"></div>
+        </div>
+
+        <div class="ops-block">
+          <div class="rail-section-label">
+            Pipeline queue
+            <span class="live-dot" title="Auto-refreshes every 30s"></span>
+          </div>
+          <div id="ops-jobs" class="table-wrap"></div>
+        </div>
+
+        <div class="ops-block">
+          <div class="rail-section-label">
+            Activity log
+            <span class="live-dot" title="Auto-refreshes every 30s"></span>
+          </div>
+          <div id="ops-log" class="table-wrap"></div>
+        </div>
+
+        <div class="ops-block">
+          <div class="rail-section-label">Always-on rules</div>
+          <div id="ops-rules" class="rules-list"></div>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <!-- ============== Citation / entity drawer ============== -->
+  <aside id="entity-drawer" class="drawer drawer-entity" hidden>
+    <div class="drawer-header">
+      <div class="drawer-title" id="entity-drawer-title"></div>
+      <button class="drawer-close" data-close="entity">×</button>
+    </div>
+    <div id="entity-drawer-body" class="drawer-body"></div>
+  </aside>
+
+  <!-- ============== Agent (Ask) drawer ============== -->
+  <aside id="ask-drawer" class="drawer drawer-ask" hidden>
+    <div class="drawer-header">
+      <div class="drawer-title">Ask BrainDB</div>
+      <button class="drawer-close" data-close="ask">×</button>
+    </div>
+    <div class="drawer-body">
+      <p class="ask-note">Same backend as the agent skill. May save / relate when you ask it to. Calls can take up to ~10 minutes if the provider is slow.</p>
+      <form id="ask-form" class="ask-form">
+        <textarea id="ask-input" rows="4" placeholder="Tell me who the user is..."></textarea>
+        <div class="ask-actions">
+          <button type="submit" id="ask-submit">Send</button>
+          <span id="ask-status" class="ask-status"></span>
+        </div>
+      </form>
+      <div id="ask-output" class="ask-output"></div>
+    </div>
+  </aside>
+
+  <div id="backdrop" class="backdrop" hidden></div>
+
+  <script type="module" src="app.js"></script>
+</body>
+</html>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -5,12 +5,15 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>BrainDB</title>
   <link rel="stylesheet" href="style.css" />
+  <!-- Graph viz: vis-network (canvas + built-in physics). Pinned version. -->
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/vis-network/9.1.9/standalone/umd/vis-network.min.js"></script>
 </head>
 <body>
   <header class="top">
     <div class="brand">BrainDB</div>
     <nav class="tabs" role="tablist">
       <button class="tab is-active" data-tab="reader" role="tab">Reader</button>
+      <button class="tab" data-tab="graph" role="tab">Graph</button>
       <button class="tab" data-tab="ops" role="tab">Ops</button>
     </nav>
     <div class="top-actions">
@@ -39,6 +42,36 @@
         <div class="rail-section-label">Relations</div>
         <div id="relations-body"></div>
       </aside>
+    </section>
+
+    <!-- ============== GRAPH ============== -->
+    <section id="graph" class="view" role="tabpanel" hidden>
+      <div class="graph-toolbar">
+        <form id="graph-search-form" class="graph-search">
+          <input id="graph-search-input" type="search" placeholder="Search BrainDB (recall) to seed the graph…" autocomplete="off" title="Uses /memory/context — pg_trgm + embeddings + graph traversal. Not Elasticsearch." />
+        </form>
+        <div id="graph-search-results" class="graph-search-results" hidden></div>
+        <div class="graph-spacer"></div>
+        <button id="graph-fit" title="Fit (F)">Fit</button>
+        <button id="graph-reset" title="Clear">Reset</button>
+        <label class="graph-toggle">
+          <input type="checkbox" id="graph-hide-kw" />
+          Hide keywords
+        </label>
+        <span id="graph-status" class="graph-status"></span>
+      </div>
+      <div id="graph-canvas" class="graph-canvas">
+        <div class="graph-empty">Open a wiki from the Reader and switch here, or use the search box above to seed.</div>
+      </div>
+      <div class="graph-legend">
+        <span class="lg lg-wiki">Wiki</span>
+        <span class="lg lg-fact">Fact</span>
+        <span class="lg lg-thought">Thought</span>
+        <span class="lg lg-keyword">Keyword</span>
+        <span class="lg lg-source">Source</span>
+        <span class="lg lg-rule">Rule</span>
+        <span class="lg-hint">Hover or zoom for labels · double-click to expand · scroll to zoom · drag to pan</span>
+      </div>
     </section>
 
     <!-- ============== OPS ============== -->

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -52,6 +52,8 @@
         </form>
         <div id="graph-search-results" class="graph-search-results" hidden></div>
         <div class="graph-spacer"></div>
+        <button id="graph-zoom-in" title="Zoom in">+</button>
+        <button id="graph-zoom-out" title="Zoom out">−</button>
         <button id="graph-fit" title="Fit (F)">Fit</button>
         <button id="graph-reset" title="Clear">Reset</button>
         <label class="graph-toggle">

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -1,0 +1,654 @@
+/* ============================================================ */
+/* BrainDB — Wikipedia-serious, 2026-professional                */
+/* ============================================================ */
+
+:root {
+  --paper: #ffffff;
+  --paper-soft: #f8f8f7;
+  --ink: #1b1b1b;
+  --ink-soft: #4a4a4a;
+  --ink-muted: #8a8a8a;
+  --rule: #eaeaea;
+  --rule-strong: #d0d0d0;
+  --accent: #0645ad;
+  --accent-soft: rgba(6, 69, 173, 0.07);
+  --highlight: #fff4c8;
+
+  --font-body: Charter, "Bitstream Charter", Georgia, "Times New Roman", serif;
+  --font-ui: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Inter, system-ui, sans-serif;
+  --font-mono: ui-monospace, SFMono-Regular, "SF Mono", Consolas, "Liberation Mono", Menlo, monospace;
+
+  --read-measure: 70ch;
+  --rail-w: 280px;
+  --relations-w: 320px;
+  --top-h: 52px;
+  --transition: 120ms ease;
+}
+
+[data-theme="dark"] {
+  --paper: #16161a;
+  --paper-soft: #1e1e22;
+  --ink: #e6e6e6;
+  --ink-soft: #b8b8b8;
+  --ink-muted: #707078;
+  --rule: #2a2a2e;
+  --rule-strong: #3a3a40;
+  --accent: #79b7ff;
+  --accent-soft: rgba(121, 183, 255, 0.10);
+  --highlight: #4a4226;
+}
+
+* { box-sizing: border-box; }
+
+/* Force-hide elements with the `hidden` attribute. Otherwise class-level
+   `display:` rules (e.g. `.drawer { display: flex }`, `#reader { display: grid }`)
+   win against the UA's `[hidden] { display: none }` because they have equal
+   or higher specificity. */
+[hidden] { display: none !important; }
+
+html, body { margin: 0; padding: 0; height: 100%; }
+
+body {
+  background: var(--paper);
+  color: var(--ink);
+  font-family: var(--font-body);
+  font-size: 16px;
+  line-height: 1.55;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+a {
+  color: var(--accent);
+  text-decoration: none;
+}
+a:hover { text-decoration: underline; }
+
+button {
+  font-family: var(--font-ui);
+  font-size: 13px;
+  color: var(--ink);
+  background: transparent;
+  border: 1px solid var(--rule-strong);
+  padding: 5px 12px;
+  cursor: pointer;
+  border-radius: 2px;
+}
+button:hover { border-color: var(--ink-soft); }
+button:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; }
+
+input, textarea {
+  font-family: var(--font-ui);
+  font-size: 14px;
+  color: var(--ink);
+  background: var(--paper);
+  border: 1px solid var(--rule-strong);
+  padding: 6px 10px;
+  border-radius: 2px;
+  width: 100%;
+}
+input:focus, textarea:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+
+/* ============================================================ */
+/* Top bar                                                       */
+/* ============================================================ */
+.top {
+  height: var(--top-h);
+  display: flex;
+  align-items: center;
+  padding: 0 18px;
+  border-bottom: 1px solid var(--rule);
+  background: var(--paper);
+  position: sticky;
+  top: 0;
+  z-index: 10;
+}
+.brand {
+  font-family: var(--font-ui);
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  font-size: 15px;
+  color: var(--ink);
+  margin-right: 24px;
+}
+.tabs { display: flex; gap: 4px; flex: 1; }
+.tab {
+  border: none;
+  background: transparent;
+  padding: 6px 12px;
+  color: var(--ink-soft);
+  font-family: var(--font-ui);
+  font-size: 13px;
+  border-radius: 0;
+  border-bottom: 2px solid transparent;
+}
+.tab:hover { color: var(--ink); border-bottom-color: var(--rule); }
+.tab.is-active { color: var(--ink); border-bottom-color: var(--ink); }
+
+.top-actions { display: flex; gap: 8px; align-items: center; }
+.ask-button {
+  font-family: var(--font-ui);
+  font-size: 12px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+.theme-toggle {
+  width: 28px; height: 28px;
+  padding: 0;
+  font-size: 14px;
+  border-color: var(--rule);
+}
+
+/* ============================================================ */
+/* View shells                                                   */
+/* ============================================================ */
+main { min-height: calc(100vh - var(--top-h)); }
+.view { display: none; }
+.view.is-active { display: block; }
+
+/* ============================================================ */
+/* Reader layout                                                 */
+/* ============================================================ */
+#reader {
+  display: grid;
+  grid-template-columns: var(--rail-w) minmax(0, 1fr) var(--relations-w);
+  grid-template-areas: "rail wiki relations";
+  min-height: calc(100vh - var(--top-h));
+}
+.rail {
+  grid-area: rail;
+  border-right: 1px solid var(--rule);
+  padding: 18px 18px 60px;
+  font-family: var(--font-ui);
+  font-size: 13px;
+  overflow-y: auto;
+  max-height: calc(100vh - var(--top-h));
+  position: sticky;
+  top: var(--top-h);
+}
+.rail-section-label {
+  font-family: var(--font-ui);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.10em;
+  text-transform: uppercase;
+  color: var(--ink-muted);
+  margin: 18px 0 10px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.search { margin: 4px 0 14px; }
+.results {
+  border: 1px solid var(--rule);
+  background: var(--paper-soft);
+  padding: 8px;
+  margin-bottom: 14px;
+  max-height: 280px;
+  overflow-y: auto;
+}
+.results-empty { color: var(--ink-muted); padding: 6px 4px; }
+.result-item {
+  padding: 6px 4px;
+  border-bottom: 1px solid var(--rule);
+  cursor: pointer;
+}
+.result-item:last-child { border-bottom: none; }
+.result-item:hover { background: var(--accent-soft); }
+.result-type {
+  display: inline-block;
+  font-family: var(--font-ui);
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--ink-muted);
+  margin-right: 6px;
+}
+.result-preview {
+  color: var(--ink-soft);
+  font-size: 12px;
+  display: block;
+  margin-top: 2px;
+}
+
+.wiki-index { list-style: none; padding: 0; margin: 0; }
+.wiki-index li {
+  padding: 4px 0;
+  border-bottom: 1px solid var(--rule);
+  cursor: pointer;
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 8px;
+}
+.wiki-index li:hover { color: var(--accent); }
+.wiki-index li.is-active { font-weight: 600; }
+.wiki-index .retired-tag {
+  font-family: var(--font-ui);
+  font-size: 10px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--ink-muted);
+}
+
+/* ============================================================ */
+/* Wiki view (the page body)                                     */
+/* ============================================================ */
+.wiki-view {
+  grid-area: wiki;
+  padding: 36px 56px 80px;
+  max-width: 100%;
+  overflow-x: hidden;
+}
+.wiki-view .empty {
+  color: var(--ink-muted);
+  font-style: italic;
+  text-align: center;
+  margin-top: 80px;
+}
+.wiki-content {
+  max-width: var(--read-measure);
+  margin: 0 auto;
+}
+.wiki-meta {
+  font-family: var(--font-ui);
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  color: var(--ink-muted);
+  text-transform: uppercase;
+  margin-bottom: 4px;
+}
+.wiki-meta .meta-piece { margin-right: 14px; }
+.wiki-meta .badge {
+  display: inline-block;
+  padding: 1px 6px;
+  border: 1px solid var(--rule-strong);
+  border-radius: 2px;
+  margin-left: 6px;
+}
+.wiki-meta .badge.consistent { color: var(--ink-soft); }
+.wiki-meta .badge.inconsistent { color: var(--accent); border-color: var(--accent); }
+.wiki-meta .badge.retired { color: var(--ink-muted); }
+
+.wiki-content h1 {
+  font-family: var(--font-body);
+  font-weight: 600;
+  font-size: 32px;
+  line-height: 1.15;
+  margin: 6px 0 24px;
+  padding-bottom: 14px;
+  border-bottom: 1px solid var(--rule);
+}
+.wiki-content h2 {
+  font-family: var(--font-body);
+  font-weight: 600;
+  font-size: 22px;
+  line-height: 1.25;
+  margin: 32px 0 12px;
+  padding-bottom: 4px;
+  border-bottom: 1px solid var(--rule);
+}
+.wiki-content h3 {
+  font-family: var(--font-body);
+  font-weight: 600;
+  font-size: 17px;
+  margin: 24px 0 8px;
+}
+
+.wiki-content p { margin: 0 0 14px; }
+.wiki-content ul, .wiki-content ol { margin: 0 0 14px; padding-left: 24px; }
+.wiki-content li { margin: 3px 0; }
+.wiki-content code {
+  font-family: var(--font-mono);
+  font-size: 0.92em;
+  background: var(--paper-soft);
+  padding: 1px 4px;
+  border-radius: 2px;
+}
+.wiki-content blockquote.callout {
+  margin: 0 0 14px;
+  padding: 10px 16px;
+  background: var(--paper-soft);
+  border-left: 3px solid var(--rule-strong);
+  font-style: italic;
+}
+.wiki-content blockquote.callout strong { font-style: normal; }
+.wiki-content blockquote.callout.summary { border-left-color: var(--accent); }
+
+.wiki-content table {
+  border-collapse: collapse;
+  margin: 0 0 18px;
+  font-size: 14px;
+  width: 100%;
+}
+.wiki-content th, .wiki-content td {
+  border: 1px solid var(--rule);
+  padding: 6px 10px;
+  text-align: left;
+  vertical-align: top;
+}
+.wiki-content th {
+  background: var(--paper-soft);
+  font-family: var(--font-ui);
+  font-weight: 600;
+  font-size: 12px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.wiki-content hr.section-divider {
+  border: none;
+  border-top: 1px solid var(--rule);
+  margin: 22px 0 0;
+}
+
+/* Citation chip — superscript-style reference */
+.ref-chip {
+  display: inline-block;
+  font-family: var(--font-ui);
+  font-size: 0.72em;
+  vertical-align: super;
+  line-height: 1;
+  color: var(--accent);
+  border: 1px solid var(--accent);
+  border-radius: 2px;
+  padding: 0 4px;
+  margin: 0 1px;
+  cursor: pointer;
+  text-decoration: none;
+  background: var(--accent-soft);
+}
+.ref-chip:hover { background: var(--accent); color: var(--paper); }
+
+/* References section at the bottom */
+.wiki-content .refs-list {
+  font-size: 14px;
+  margin-top: 24px;
+  padding-top: 14px;
+  border-top: 1px solid var(--rule);
+}
+
+/* ============================================================ */
+/* Relations panel                                               */
+/* ============================================================ */
+.relations {
+  grid-area: relations;
+  border-left: 1px solid var(--rule);
+  padding: 18px 18px 60px;
+  font-family: var(--font-ui);
+  font-size: 12px;
+  overflow-y: auto;
+  max-height: calc(100vh - var(--top-h));
+  position: sticky;
+  top: var(--top-h);
+}
+.relations-group { margin-bottom: 18px; }
+.relations-group h4 {
+  margin: 0 0 6px;
+  font-family: var(--font-ui);
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ink-soft);
+  font-weight: 600;
+}
+.relation-row {
+  padding: 5px 0;
+  border-bottom: 1px solid var(--rule);
+  cursor: pointer;
+}
+.relation-row:hover { color: var(--accent); }
+.relation-row .preview {
+  color: var(--ink-muted);
+  font-size: 11px;
+  display: block;
+  margin-top: 1px;
+  line-height: 1.45;
+}
+
+/* ============================================================ */
+/* Drawers (slide-over from right)                              */
+/* ============================================================ */
+.drawer {
+  position: fixed;
+  top: 0;
+  right: 0;
+  height: 100vh;
+  width: 480px;
+  max-width: 90vw;
+  background: var(--paper);
+  border-left: 1px solid var(--rule-strong);
+  z-index: 50;
+  display: flex;
+  flex-direction: column;
+  box-shadow: -2px 0 0 var(--rule);
+}
+.drawer-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 18px;
+  border-bottom: 1px solid var(--rule);
+  height: var(--top-h);
+}
+.drawer-title {
+  font-family: var(--font-ui);
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  color: var(--ink);
+}
+.drawer-close {
+  border: none;
+  font-size: 22px;
+  line-height: 1;
+  padding: 0 6px;
+  color: var(--ink-soft);
+}
+.drawer-close:hover { color: var(--ink); border: none; }
+.drawer-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 20px 24px;
+  font-family: var(--font-body);
+  font-size: 15px;
+  line-height: 1.55;
+}
+.drawer-body .entity-section { margin-bottom: 20px; }
+.drawer-body .entity-section h4 {
+  font-family: var(--font-ui);
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ink-soft);
+  margin: 0 0 6px;
+}
+.drawer-body .entity-meta {
+  font-family: var(--font-ui);
+  font-size: 12px;
+  color: var(--ink-muted);
+  margin-bottom: 16px;
+}
+.drawer-body .entity-meta .pill {
+  display: inline-block;
+  background: var(--paper-soft);
+  padding: 1px 7px;
+  border-radius: 2px;
+  margin-right: 6px;
+}
+.drawer-body pre {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  background: var(--paper-soft);
+  padding: 8px 10px;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.18);
+  z-index: 40;
+}
+[data-theme="dark"] .backdrop { background: rgba(0, 0, 0, 0.40); }
+
+/* ============================================================ */
+/* Ask drawer specifics                                          */
+/* ============================================================ */
+.ask-note {
+  font-family: var(--font-ui);
+  font-size: 12px;
+  color: var(--ink-muted);
+  margin: 0 0 12px;
+  line-height: 1.45;
+}
+.ask-form textarea {
+  font-family: var(--font-body);
+  font-size: 15px;
+  resize: vertical;
+  min-height: 80px;
+}
+.ask-actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-top: 10px;
+}
+.ask-status {
+  font-family: var(--font-ui);
+  font-size: 12px;
+  color: var(--ink-muted);
+}
+.ask-output {
+  margin-top: 20px;
+  font-family: var(--font-body);
+  font-size: 15px;
+  line-height: 1.6;
+  border-top: 1px solid var(--rule);
+  padding-top: 16px;
+}
+.ask-output:empty { display: none; }
+
+/* ============================================================ */
+/* Ops view                                                      */
+/* ============================================================ */
+#ops {
+  padding: 36px 56px 80px;
+  max-width: 1280px;
+  margin: 0 auto;
+}
+.ops-grid { display: grid; gap: 32px; }
+.ops-block { font-family: var(--font-ui); font-size: 13px; }
+
+.stats-strip {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(110px, 1fr));
+  gap: 14px;
+}
+.stats-strip .stat {
+  border: 1px solid var(--rule);
+  padding: 10px 12px;
+  background: var(--paper-soft);
+}
+.stats-strip .stat .v {
+  font-family: var(--font-body);
+  font-size: 22px;
+  font-weight: 600;
+}
+.stats-strip .stat .k {
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ink-muted);
+  margin-top: 2px;
+}
+
+.table-wrap { overflow-x: auto; }
+table.ops-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-family: var(--font-mono);
+  font-size: 12px;
+}
+table.ops-table th, table.ops-table td {
+  border-bottom: 1px solid var(--rule);
+  padding: 5px 10px;
+  text-align: left;
+  vertical-align: top;
+  white-space: nowrap;
+}
+table.ops-table th {
+  font-family: var(--font-ui);
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ink-soft);
+  font-weight: 600;
+  background: var(--paper-soft);
+  position: sticky;
+  top: 0;
+}
+table.ops-table tr.highlight-consolidate { background: var(--highlight); }
+table.ops-table td.id-cell {
+  color: var(--ink-muted);
+  max-width: 240px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+table.ops-table td.context {
+  font-family: var(--font-body);
+  white-space: normal;
+  max-width: 420px;
+}
+
+.rules-list { display: grid; gap: 6px; }
+.rule-row {
+  padding: 6px 10px;
+  border: 1px solid var(--rule);
+  background: var(--paper-soft);
+  font-family: var(--font-body);
+  font-size: 14px;
+}
+.rule-row .rule-meta {
+  font-family: var(--font-ui);
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  color: var(--ink-muted);
+  margin-bottom: 2px;
+  text-transform: uppercase;
+}
+
+.live-dot {
+  display: inline-block;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--accent);
+  opacity: 0.65;
+  margin-left: 4px;
+}
+
+/* ============================================================ */
+/* Responsive degradation                                        */
+/* ============================================================ */
+@media (max-width: 1100px) {
+  #reader {
+    grid-template-columns: var(--rail-w) minmax(0, 1fr);
+    grid-template-areas: "rail wiki";
+  }
+  .relations { display: none; }
+}
+@media (max-width: 720px) {
+  #reader {
+    grid-template-columns: 1fr;
+    grid-template-areas: "wiki";
+  }
+  .rail { display: none; }
+  .wiki-view { padding: 24px 18px 60px; }
+  #ops { padding: 24px 18px 60px; }
+  .drawer { width: 100%; max-width: 100%; }
+}

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -207,6 +207,35 @@ main { min-height: calc(100vh - var(--top-h)); }
   color: var(--ink-muted);
   margin-right: 6px;
 }
+.result-breakdown {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  padding: 6px 4px;
+  border-bottom: 1px solid var(--rule);
+  margin-bottom: 4px;
+}
+.type-pill {
+  display: inline-block;
+  font-family: var(--font-ui);
+  font-size: 9px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--paper);
+  padding: 1px 5px;
+  border-radius: 2px;
+  margin-right: 4px;
+  vertical-align: middle;
+}
+.type-pill.type-wiki      { background: var(--accent); }
+.type-pill.type-fact      { background: var(--ink-soft); }
+.type-pill.type-thought   { background: var(--ink-soft); border: 1px dashed var(--paper); padding: 0 4px; }
+.type-pill.type-keyword   { background: #b86c00; }
+.type-pill.type-source,
+.type-pill.type-datasource { background: #226666; }
+.type-pill.type-rule      { background: #7a4a8a; }
+.result-name { font-weight: 500; }
 .result-preview {
   color: var(--ink-soft);
   font-size: 12px;
@@ -272,6 +301,12 @@ main { min-height: calc(100vh - var(--top-h)); }
 .wiki-meta .badge.consistent { color: var(--ink-soft); }
 .wiki-meta .badge.inconsistent { color: var(--accent); border-color: var(--accent); }
 .wiki-meta .badge.retired { color: var(--ink-muted); }
+.wiki-meta .graph-link {
+  color: var(--accent);
+  text-decoration: none;
+  margin-left: 4px;
+}
+.wiki-meta .graph-link:hover { text-decoration: underline; }
 
 .wiki-content h1 {
   font-family: var(--font-body);
@@ -631,6 +666,160 @@ table.ops-table td.context {
   opacity: 0.65;
   margin-left: 4px;
 }
+
+/* ============================================================ */
+/* Graph view                                                    */
+/* ============================================================ */
+#graph {
+  display: flex;
+  flex-direction: column;
+  height: calc(100vh - var(--top-h));
+}
+
+.graph-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 5px 14px;
+  border-bottom: 1px solid var(--rule);
+  font-family: var(--font-ui);
+  font-size: 11px;
+  background: var(--paper);
+  position: relative;
+  z-index: 5;
+}
+.graph-toolbar .graph-spacer { flex: 1; }
+.graph-search { flex: 0 0 260px; }
+.graph-search input {
+  font-size: 12px;
+  padding: 4px 8px;
+}
+.graph-search-results {
+  position: absolute;
+  top: 100%;
+  left: 18px;
+  width: 320px;
+  background: var(--paper);
+  border: 1px solid var(--rule-strong);
+  border-top: none;
+  max-height: 300px;
+  overflow-y: auto;
+  z-index: 6;
+}
+.graph-search-results .result-item {
+  padding: 6px 10px;
+  border-bottom: 1px solid var(--rule);
+  cursor: pointer;
+}
+.graph-search-results .result-item:last-child { border-bottom: none; }
+.graph-search-results .result-item:hover { background: var(--accent-soft); }
+.graph-search-results .result-empty { padding: 8px; color: var(--ink-muted); }
+
+.graph-toolbar button {
+  font-size: 11px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  padding: 4px 10px;
+}
+.graph-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--ink-soft);
+  cursor: pointer;
+  user-select: none;
+}
+.graph-toggle input { width: auto; }
+
+.graph-status {
+  font-size: 10px;
+  color: var(--ink-muted);
+  min-width: 60px;
+  text-align: right;
+}
+
+.graph-canvas {
+  flex: 1 1 auto;
+  width: 100%;
+  position: relative;
+  background: var(--paper-soft);
+  overflow: hidden;
+}
+.graph-empty {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--ink-muted);
+  font-style: italic;
+  pointer-events: none;
+  text-align: center;
+  padding: 20px;
+}
+.graph-canvas:not(:empty) .graph-empty { display: none; }
+.graph-canvas canvas { display: block; }
+
+.graph-legend {
+  display: flex;
+  flex-wrap: nowrap;
+  align-items: center;
+  gap: 12px;
+  padding: 4px 14px;
+  border-top: 1px solid var(--rule);
+  background: var(--paper);
+  font-family: var(--font-ui);
+  font-size: 10px;
+  color: var(--ink-soft);
+  overflow-x: auto;
+}
+.graph-legend .lg {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+.graph-legend .lg::before {
+  content: "";
+  display: inline-block;
+  width: 12px;
+  height: 10px;
+  background: var(--ink-muted);
+  border: 1px solid var(--ink-soft);
+  border-radius: 2px;
+}
+.graph-legend .lg-wiki::before { background: var(--accent); border-color: var(--accent); border-radius: 3px; }
+.graph-legend .lg-fact::before { background: var(--paper-soft); border-color: var(--ink-soft); border-radius: 50%; }
+.graph-legend .lg-thought::before { background: var(--paper-soft); border-color: var(--ink-muted); border-style: dashed; border-radius: 50%; }
+.graph-legend .lg-keyword::before { background: #b86c00; border-color: #b86c00; transform: rotate(45deg); width: 8px; height: 8px; }
+.graph-legend .lg-source::before { background: #226666; border-color: #226666; }
+.graph-legend .lg-rule::before { background: #7a4a8a; border-color: #7a4a8a; border-radius: 3px; }
+.graph-legend .lg-hint {
+  margin-left: auto;
+  color: var(--ink-muted);
+  font-style: italic;
+}
+@media (max-width: 1100px) {
+  .graph-legend .lg-hint { display: none; }
+}
+
+.graph-toast {
+  position: fixed;
+  bottom: 24px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--ink);
+  color: var(--paper);
+  padding: 8px 14px;
+  font-family: var(--font-ui);
+  font-size: 12px;
+  border-radius: 2px;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 200ms ease;
+  z-index: 100;
+  max-width: 80vw;
+}
+.graph-toast.show { opacity: 0.95; }
 
 /* ============================================================ */
 /* Responsive degradation                                        */

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -187,7 +187,7 @@ main { min-height: calc(100vh - var(--top-h)); }
   background: var(--paper-soft);
   padding: 8px;
   margin-bottom: 14px;
-  max-height: 280px;
+  max-height: 50vh;
   overflow-y: auto;
 }
 .results-empty { color: var(--ink-muted); padding: 6px 4px; }
@@ -235,6 +235,63 @@ main { min-height: calc(100vh - var(--top-h)); }
 .type-pill.type-source,
 .type-pill.type-datasource { background: #226666; }
 .type-pill.type-rule      { background: #7a4a8a; }
+.type-pill.type-unknown   { background: var(--ink-muted); color: var(--paper); }
+
+.actor-pill {
+  display: inline-block;
+  font-family: var(--font-ui);
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  color: var(--paper);
+  padding: 2px 6px;
+  border-radius: 2px;
+  vertical-align: middle;
+  white-space: nowrap;
+}
+.actor-pill.actor-maintainer { background: #7a4a8a; }
+.actor-pill.actor-writer     { background: var(--accent); }
+.actor-pill.actor-scheduler  { background: var(--ink-muted); }
+.actor-pill.actor-watcher    { background: #226666; }
+.actor-pill.actor-system     { background: var(--ink-soft); }
+.ink-muted { color: var(--ink-muted); }
+
+.entity-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  cursor: inherit;
+  min-width: 0;
+}
+.entity-chip .entity-name {
+  font-family: var(--font-ui);
+  font-size: 12px;
+  color: var(--ink);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 220px;
+}
+.entity-filepath {
+  font-family: var(--font-ui);
+  font-size: 11px;
+  color: var(--ink-muted);
+  padding: 6px 12px;
+  border-bottom: 1px solid var(--rule);
+  word-break: break-all;
+}
+.entity-filepath .filepath-label {
+  font-weight: 600;
+  margin-right: 4px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+.entity-filepath code {
+  background: var(--paper-soft);
+  padding: 1px 4px;
+  border-radius: 2px;
+  user-select: all;
+}
 .result-name { font-weight: 500; }
 .result-preview {
   color: var(--ink-soft);
@@ -523,6 +580,47 @@ main { min-height: calc(100vh - var(--top-h)); }
   word-break: break-word;
 }
 
+.drawer-actions-row {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-bottom: 12px;
+  padding-bottom: 12px;
+  border-bottom: 1px solid var(--rule);
+}
+.drawer-action {
+  display: inline-block;
+  font-family: var(--font-ui);
+  font-size: 12px;
+  font-weight: 500;
+  letter-spacing: 0.02em;
+  text-decoration: none;
+  color: var(--paper);
+  background: var(--accent);
+  padding: 5px 12px;
+  border-radius: 2px;
+  border: 1px solid var(--accent);
+  cursor: pointer;
+}
+.drawer-action:hover {
+  text-decoration: none;
+  background: var(--ink);
+  border-color: var(--ink);
+}
+.drawer-action.secondary {
+  background: var(--paper-soft);
+  color: var(--ink-soft);
+  border-color: var(--rule-strong);
+  margin-top: 8px;
+  width: 100%;
+  text-align: center;
+}
+.drawer-action.secondary:hover {
+  background: var(--accent-soft);
+  color: var(--accent);
+  border-color: var(--accent);
+}
+
 .backdrop {
   position: fixed;
   inset: 0;
@@ -627,7 +725,14 @@ table.ops-table th {
   position: sticky;
   top: 0;
 }
+/* Zebra stripes for ops tables — adjacent lines easier to follow */
+table.ops-table tbody tr:nth-child(even) { background: var(--paper-soft); }
+table.ops-table tbody tr:hover { background: var(--accent-soft); }
 table.ops-table tr.highlight-consolidate { background: var(--highlight); }
+table.ops-table tr.row-failed td { color: #b14a4a; }
+table.ops-table tr.row-failed { background: rgba(177, 74, 74, 0.06); }
+table.ops-table td.context-error { color: #b14a4a; }
+table.ops-table td.hover-resolve { cursor: help; }
 table.ops-table td.id-cell {
   color: var(--ink-muted);
   max-width: 240px;

--- a/frontend/wiki-render.js
+++ b/frontend/wiki-render.js
@@ -1,0 +1,270 @@
+// ============================================================
+// wiki-render.js — minimal Markdown renderer for BrainDB wiki
+// body grammar. No dependencies.
+//
+// Handles:
+//   <!-- wiki:meta key=value key=value … -->
+//   # Heading, ## Heading, ### Heading
+//   > **Summary:** … and > **Disambiguation:** … callouts
+//   <!-- section:slug --> dividers
+//   GFM tables (| col | col |)
+//   - / * / 1. lists
+//   **bold**, `code`, [text](url)
+//   [[ref:UUID|optional display]] and [[ref:UUID]] chips,
+//     tolerantly handling the grouped form [[ref:a], [ref:b]]
+// ============================================================
+
+const UUID_RE = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i;
+
+function escapeHtml(s) {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+// Inline pass: refs → chips, **bold**, `code`, [text](url)
+function renderInline(text) {
+  // Protect anything dangerous, then progressively replace tokens.
+  let out = escapeHtml(text);
+
+  // [[ref:UUID|display]]  and  [[ref:UUID]]
+  // Tolerant: also catches  [ref:UUID]  inside a grouped  [[ref:a], [ref:b]]
+  out = out.replace(/\[\[ref:([0-9a-f-]+)(?:\|([^\]]+))?\]\]/gi,
+    (_, id, disp) => refChip(id, disp));
+  out = out.replace(/\[ref:([0-9a-f-]+)(?:\|([^\]]+))?\]/gi,
+    (_, id, disp) => refChip(id, disp));
+
+  // [text](url)
+  out = out.replace(/\[([^\]]+)\]\(([^)]+)\)/g,
+    (_, label, url) => `<a href="${url}" target="_blank" rel="noopener">${label}</a>`);
+
+  // `code`
+  out = out.replace(/`([^`]+)`/g, (_, c) => `<code>${c}</code>`);
+
+  // **bold**
+  out = out.replace(/\*\*([^*]+)\*\*/g, (_, b) => `<strong>${b}</strong>`);
+
+  return out;
+}
+
+function refChip(id, displayMaybe) {
+  if (!UUID_RE.test(id)) return `<span class="ref-chip-broken">${escapeHtml(id)}</span>`;
+  const display = displayMaybe ? escapeHtml(displayMaybe) : id.slice(0, 6);
+  return `<a class="ref-chip" data-ref="${id}" title="${id}" href="#">${display}</a>`;
+}
+
+// Parse  <!-- wiki:meta key=value key=value -->  from the body's first line.
+// Tolerant: keys are unquoted; values may contain semicolons; the key list is
+// space-separated; we don't enforce a fixed schema.
+function parseMeta(line) {
+  const m = line.match(/<!--\s*wiki:meta\s+(.+?)\s*-->/);
+  if (!m) return null;
+  const meta = {};
+  const re = /(\w+)=("[^"]*"|[^\s]+)/g;
+  let mm;
+  while ((mm = re.exec(m[1])) !== null) {
+    meta[mm[1]] = mm[2].replace(/^"|"$/g, "");
+  }
+  return meta;
+}
+
+// Top-level: turn the full wiki body markdown into HTML.
+// Returns { html, meta, refs:[uuid...] }
+export function renderWiki(body) {
+  if (!body) return { html: "", meta: null, refs: [] };
+
+  const lines = body.split(/\r?\n/);
+  let meta = null;
+  let i = 0;
+
+  // 1. meta header (first non-empty line that matches)
+  while (i < lines.length && lines[i].trim() === "") i++;
+  if (i < lines.length) {
+    const candidate = parseMeta(lines[i]);
+    if (candidate) {
+      meta = candidate;
+      i++;
+    }
+  }
+
+  const out = [];
+  const refs = new Set();
+
+  while (i < lines.length) {
+    const line = lines[i];
+
+    // Section divider marker
+    const sec = line.match(/^<!--\s*section:([\w-]+)\s*-->/);
+    if (sec) {
+      out.push(`<hr class="section-divider" data-section="${sec[1]}" />`);
+      i++;
+      continue;
+    }
+
+    // Other HTML comments — skip
+    if (/^<!--.*-->$/.test(line.trim())) { i++; continue; }
+
+    // Blank line
+    if (line.trim() === "") { i++; continue; }
+
+    // # Title  (h1)
+    if (/^#\s+/.test(line)) {
+      const text = line.replace(/^#\s+/, "");
+      out.push(`<h1>${renderInline(text)}</h1>`);
+      i++;
+      continue;
+    }
+    // ## Heading (h2)
+    if (/^##\s+/.test(line)) {
+      const text = line.replace(/^##\s+/, "");
+      out.push(`<h2>${renderInline(text)}</h2>`);
+      i++;
+      continue;
+    }
+    // ### Heading (h3)
+    if (/^###\s+/.test(line)) {
+      const text = line.replace(/^###\s+/, "");
+      out.push(`<h3>${renderInline(text)}</h3>`);
+      i++;
+      continue;
+    }
+
+    // Callout: > **Summary:** ...   (multi-line — collect contiguous > lines)
+    if (/^>\s*/.test(line)) {
+      const block = [];
+      while (i < lines.length && /^>\s*/.test(lines[i])) {
+        block.push(lines[i].replace(/^>\s?/, ""));
+        i++;
+      }
+      const joined = block.join(" ");
+      const kindMatch = joined.match(/^\*\*(Summary|Disambiguation)[:\s]\*\*\s*(.+)/i);
+      let cls = "callout";
+      if (kindMatch) {
+        cls += " " + kindMatch[1].toLowerCase();
+        // Escape the label, render-inline the prose, concatenate outside —
+        // never put pre-built HTML inside a string that goes through
+        // renderInline (escapeHtml would mangle the tags).
+        const labelText = kindMatch[1];
+        const rest = kindMatch[2];
+        out.push(`<blockquote class="${cls}"><strong>${escapeHtml(labelText)}:</strong> ${renderInline(rest)}</blockquote>`);
+      } else {
+        out.push(`<blockquote class="${cls}">${renderInline(joined)}</blockquote>`);
+      }
+      continue;
+    }
+
+    // Table (GFM): a line starting with `|`, followed by a separator line
+    if (/^\|/.test(line) && i + 1 < lines.length && /^\|\s*[-:|\s]+$/.test(lines[i + 1])) {
+      const rows = [];
+      while (i < lines.length && /^\|/.test(lines[i])) {
+        rows.push(lines[i]);
+        i++;
+      }
+      out.push(renderTable(rows));
+      continue;
+    }
+
+    // Bullet list (- or *)
+    if (/^[-*]\s+/.test(line)) {
+      const items = [];
+      while (i < lines.length && /^[-*]\s+/.test(lines[i])) {
+        items.push(lines[i].replace(/^[-*]\s+/, ""));
+        i++;
+      }
+      const li = items.map(it => `<li>${renderInline(it)}</li>`).join("");
+      out.push(`<ul>${li}</ul>`);
+      continue;
+    }
+
+    // Numbered list
+    if (/^\d+\.\s+/.test(line)) {
+      const items = [];
+      while (i < lines.length && /^\d+\.\s+/.test(lines[i])) {
+        items.push(lines[i].replace(/^\d+\.\s+/, ""));
+        i++;
+      }
+      const li = items.map(it => `<li>${renderInline(it)}</li>`).join("");
+      out.push(`<ol>${li}</ol>`);
+      continue;
+    }
+
+    // Paragraph: gather consecutive non-empty lines
+    const para = [];
+    while (i < lines.length && lines[i].trim() !== ""
+      && !/^[#>|-]/.test(lines[i])
+      && !/^\d+\.\s+/.test(lines[i])
+      && !/^<!--/.test(lines[i].trim())) {
+      para.push(lines[i]);
+      i++;
+    }
+    if (para.length > 0) {
+      out.push(`<p>${renderInline(para.join(" "))}</p>`);
+    } else {
+      // safety — should not happen, but advance to avoid an infinite loop
+      i++;
+    }
+  }
+
+  // Collect all referenced UUIDs from the rendered HTML for caller use
+  const html = out.join("\n");
+  const refRe = /data-ref="([0-9a-f-]+)"/gi;
+  let m;
+  while ((m = refRe.exec(html)) !== null) refs.add(m[1]);
+
+  return { html, meta, refs: Array.from(refs) };
+}
+
+function renderTable(rows) {
+  // rows[0] = header, rows[1] = separator, rows[2..] = body
+  const splitRow = r => r.replace(/^\|/, "").replace(/\|$/, "").split("|").map(c => c.trim());
+  const header = splitRow(rows[0]);
+  const body = rows.slice(2).map(splitRow);
+  const th = header.map(c => `<th>${renderInline(c)}</th>`).join("");
+  const tb = body.map(r => "<tr>" + r.map(c => `<td>${renderInline(c)}</td>`).join("") + "</tr>").join("");
+  return `<table><thead><tr>${th}</tr></thead><tbody>${tb}</tbody></table>`;
+}
+
+// Extract sections from rendered HTML for a TOC. Returns [{slug, title}]
+export function extractSections(body) {
+  if (!body) return [];
+  const sections = [];
+  const lines = body.split(/\r?\n/);
+  for (let i = 0; i < lines.length; i++) {
+    const sec = lines[i].match(/^<!--\s*section:([\w-]+)\s*-->/);
+    if (sec) {
+      // Look ahead for the next heading or callout-bold to use as a title
+      let title = sec[1].replace(/-/g, " ");
+      for (let j = i + 1; j < Math.min(i + 4, lines.length); j++) {
+        const h = lines[j].match(/^#{2,3}\s+(.+)/);
+        if (h) { title = h[1]; break; }
+      }
+      sections.push({ slug: sec[1], title });
+    }
+  }
+  return sections;
+}
+
+// Compare inline [[ref:UUID]] chips to the wiki's `summarises` relations.
+// Returns { inline: N, relations: M, consistent: bool, only_inline: [...], only_relations: [...] }
+// Mirrors the spirit of export_wikis._consistency.
+export function consistencyCheck(body, summarisesIds) {
+  const inline = new Set();
+  if (body) {
+    const re = /\[\[?ref:([0-9a-f-]+)/gi;
+    let m;
+    while ((m = re.exec(body)) !== null) inline.add(m[1]);
+  }
+  const rel = new Set(summarisesIds || []);
+  const onlyInline = [...inline].filter(x => !rel.has(x));
+  const onlyRel = [...rel].filter(x => !inline.has(x));
+  return {
+    inline: inline.size,
+    relations: rel.size,
+    consistent: onlyInline.length === 0 && onlyRel.length === 0,
+    only_inline: onlyInline,
+    only_relations: onlyRel,
+  };
+}


### PR DESCRIPTION
## Summary

- **Read-only frontend** under `frontend/` — vanilla-JS, no build step, no npm. Three views (Reader / Graph / Ops) + an Ask drawer that talks to the agent endpoint.
- **Universal entity-chip resolver** so no raw UUID surfaces in normal user flow — every UI render that previously showed a UUID now resolves to a `[type-pill] canonical-name` chip.
- **Graph tab** with deterministic ring expansion, one-shot physics (graph never drifts under the mouse), type-shaped nodes, retired-wiki badge in the seed search.
- **Ops tab** rewritten: actor pills (Maintainer / Writer / Scheduler / Watcher), readable target-wiki + entity chips, zebra stripes, NOTE column that distinguishes benign rationale from real errors.
- **README** embeds the new YouTube walkthrough at the top.
- Merges [@WarGloom](https://github.com/WarGloom)'s relations-endpoint fix ([PR #5](https://github.com/dimknaf/braindb/pull/5)) that landed on `main` after v0.2.0 was cut.

## Walkthrough video

▶ https://youtu.be/AJ7iMOj4vvA

## Test plan

- [ ] Reader: open a wiki, click citation chips, search the rail (debounced) and confirm the type-pill breakdown bar appears
- [ ] Graph: seed from a wiki, click to expand, scroll/drag-pan, zoom buttons, retired-wiki badge appears in the search dropdown
- [ ] Ops: pipeline queue + activity log render with actor pills and readable chips (no UUIDs visible)
- [ ] Drawer: "Open full wiki" navigates correctly; "Load more" pages a big datasource body; file_path renders as copy-able code (no broken `file://` link)
- [ ] Backend untouched — agent endpoint and `/memory/*` calls still respond as before
