### PR TITLE
v0.4.0 -- per-edge LLM scoring + view_tree nested JSON

### DIFF
--- a/BRAINDB_GUIDE.md
+++ b/BRAINDB_GUIDE.md
@@ -14,8 +14,11 @@ fall back to flat SQL.
    discovery, understanding ("what do we know about X?"). Keyword-mediated
    fuzzy + embeddings + graph + ranking.
 2. **`GET /api/v1/memory/tree/<id>?max_depth=N`** — reveals an entity's
-   connections in one call (relations + 1-N hop neighbours + edge scores).
-   Especially useful when you have an entity ID and want its graph context.
+   neighbourhood as a nested JSON tree (root keyed by `entity_type`,
+   `children` arrays per node, keyword + retired-wiki noise filtered,
+   `_truncated` last-child marker if more remain). Especially useful when
+   you have an entity ID and want its graph context. On hub entities
+   (wikis with many connections) pass `max_depth=3` for narrative chains.
 3. **`POST /api/v1/agent/query`** ("delegate to a subagent") — for multi-step
    investigation / disambiguation.
 4. `GET /api/v1/entities…` and `/entities/<id>/relations` — direct lookups.
@@ -290,7 +293,12 @@ curl -X POST http://localhost:8000/api/v1/memory/context \
 ```bash
 curl http://localhost:8000/api/v1/memory/tree/<UUID>?max_depth=2
 ```
-Returns the entity and all its graph connections organized by depth and relevance.
+Returns the entity and its 1-N hop neighbourhood as a nested JSON tree (root
+keyed by `entity_type`, `children` arrays per node, multi-path first-wins by
+best accumulated path score, keyword + retired-wiki noise filtered by default).
+Optional query params: `include_keywords` (default `false`), `top_k` (default
+`40`), `min_path_score` (default `0.0`). A `_truncated` last-child marker
+appears when `top_k` clips the result.
 
 ### Get All Rules
 ```bash

--- a/BRAINDB_GUIDE.md
+++ b/BRAINDB_GUIDE.md
@@ -5,6 +5,26 @@ The API runs at **http://localhost:8000**. Everything is done via HTTP calls.
 
 ---
 
+## ⚠ TOOL PRIORITY (read this first)
+
+BrainDB's value is the graph + embeddings + ranking. Use that power; do not
+fall back to flat SQL.
+
+1. **`POST /api/v1/memory/context`** — default for **query-driven** recall,
+   discovery, understanding ("what do we know about X?"). Keyword-mediated
+   fuzzy + embeddings + graph + ranking.
+2. **`GET /api/v1/memory/tree/<id>?max_depth=N`** — default for **entity-driven**
+   neighbourhood exploration ("what's around entity Y?"). Returns the chain
+   with relation types and edge scores in one call.
+3. **`POST /api/v1/agent/query`** ("delegate to a subagent") — for multi-step
+   investigation / disambiguation.
+4. `GET /api/v1/entities…` and `/entities/<id>/relations` — direct lookups.
+5. **`POST /api/v1/memory/sql` ⚠ exception only** — aggregates (counts,
+   GROUP BY, activity-log joins). NEVER for recall, discovery, similarity,
+   understanding, or "what's around this entity" — those are the tools above.
+
+---
+
 ## Entity Types
 
 | Type | What to store |

--- a/BRAINDB_GUIDE.md
+++ b/BRAINDB_GUIDE.md
@@ -13,9 +13,9 @@ fall back to flat SQL.
 1. **`POST /api/v1/memory/context`** — default for **query-driven** recall,
    discovery, understanding ("what do we know about X?"). Keyword-mediated
    fuzzy + embeddings + graph + ranking.
-2. **`GET /api/v1/memory/tree/<id>?max_depth=N`** — default for **entity-driven**
-   neighbourhood exploration ("what's around entity Y?"). Returns the chain
-   with relation types and edge scores in one call.
+2. **`GET /api/v1/memory/tree/<id>?max_depth=N`** — reveals an entity's
+   connections in one call (relations + 1-N hop neighbours + edge scores).
+   Especially useful when you have an entity ID and want its graph context.
 3. **`POST /api/v1/agent/query`** ("delegate to a subagent") — for multi-step
    investigation / disambiguation.
 4. `GET /api/v1/entities…` and `/entities/<id>/relations` — direct lookups.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,79 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0] — 2026-06-03
+
+Headline: a focused pass on recall quality and the `view_tree` tool. The
+per-edge LLM judgment that was missing on `create_relation` is now wired
+through to graph scoring, and `view_tree` returns a nested JSON tree the
+agent can actually navigate (vs the depth-grouped text that silently
+clipped 70% of connections on popular wikis).
+
+### Changed
+
+- **`view_tree` / `GET /api/v1/memory/tree/<id>` — nested JSON shape.**
+  Root keyed by `entity_type`, `children` arrays per node, multi-path
+  first-wins by best accumulated path score, keyword + retired-wiki noise
+  filtered by default, `_truncated` last-child marker when more remain.
+  One shared builder (`build_entity_tree` in `braindb/services/tree.py`)
+  for the HTTP endpoint and the agent tool — no behaviour drift. New
+  optional query params: `include_keywords` (default `false`), `top_k`
+  (default `40`), `min_path_score` (default `0.0`). Bench: Path B (Qwen
+  27B) 5/5 PASS, **−25% wall-clock**, **−26% tool calls**, **zero
+  `delegate` calls** on the hardest question (was 2). Path A (Claude
+  Code + curl skill) 5/5 PASS, `view_tree` usage 0 → 1-2 calls — the
+  structured shape is now usable in practice. Numbers in
+  `benchmarks/runs/round-2f_comparison.md`.
+- **`create_relation` writes both edge scores.** The `importance_score`
+  column had been NULL for every agent-created row since day one; the
+  parameter is now on the tool, the watcher's extraction prompt no
+  longer dictates literal score values (the LLM judges per docstring),
+  and the graph CTE multiplies `relevance_score × COALESCE(
+  importance_score, 0.5) × depth_penalty` per hop. The
+  `is_bidirectional` field on `relations` is now ignored by graph
+  traversal — every edge walks both ways (matching what
+  `services/tree.py` already did). The field stays in the schema for
+  backwards compatibility.
+- **Seed-similarity propagation in graph scoring.** Recall hops carry
+  the seed's similarity score forward through the graph; the depth
+  multiplier is softened so default-quality intermediates don't collapse
+  depth-2/3 results.
+- **Prompts**: `view_tree` reframed as a capability for "explore around
+  this entity"; `search_sql` demoted to an aggregates-only exception.
+  Same wording applied to `system_prompt.md`, both skill files
+  (`skills/braindb/SKILL.md`, `skills/braindb-agent/SKILL.md`),
+  `README.md`, and `BRAINDB_GUIDE.md`.
+
+### Fixed
+
+- **`view_tree` keyword noise**: keyword entities were leaking through
+  non-`tagged_with` edges (e.g. `similar_to` between keywords). The
+  filter now applies to target `entity_type='keyword'` as well as the
+  edge type. Surfaced by the new nested JSON shape and fixed in the
+  same commit.
+- **`view_tree` duplicate retired-wiki siblings**: when the wiki
+  maintainer creates a wiki and later consolidates duplicates, the
+  retired ones used to still appear in `view_tree` output as duplicate
+  siblings of the canonical wiki. The tree CTE now LEFT JOINs
+  `wikis_ext` and skips rows where `retired_at IS NOT NULL`.
+- **Test isolation in `tests/test_ingest.py`**: the three ingest tests
+  used fixed content strings, so a previous run's row in the DB caused
+  dedup-by-hash to fire and the 201 assertion to fail on subsequent
+  runs. Each test now prepends a per-run `uuid.uuid4().hex` to its
+  content.
+- **Missing test dep**: added `pytest-asyncio==0.23.7` to
+  `[project.optional-dependencies].dev`. Existing
+  `@pytest.mark.asyncio` tests were silently failing on clean installs.
+
+### Upgrading from v0.3.0
+
+No DB migration. No env-var changes. The wiki maintainer's existing
+retired-wiki pipeline now also gates `view_tree` traversal — old wikis
+with `retired_at IS NOT NULL` are silently skipped in tree output (they
+remain readable via `GET /api/v1/entities/<id>`). `pyproject.toml`
+version field was at `0.2.0` in v0.3.0's tagged release (the bump was
+missed); this release catches it up to `0.4.0` in one step.
+
 ## [0.3.0] — 2026-05-25
 
 Headline: a small read-only frontend lands so humans can browse the same

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Drop a markdown file into `data/sources/` and the watcher sidecar picks it up wi
 | POST | `/api/v1/entities/datasources/ingest` | Read a file from disk and create a datasource entity |
 | POST | `/api/v1/memory/search` | Fast fuzzy search |
 | POST | `/api/v1/memory/context` | Full retrieval: fuzzy → graph → decay → rank |
-| GET | `/api/v1/memory/tree/{id}` | Entity graph tree — connections by depth |
+| GET | `/api/v1/memory/tree/{id}` | Entity neighbourhood as a nested JSON tree |
 | GET | `/api/v1/memory/log` | Activity log — when and how things happened |
 | POST | `/api/v1/memory/sql` | Read-only SQL queries (SELECT/WITH only) |
 | POST | `/api/v1/memory/generate-embeddings` | Batch-generate keyword embeddings |

--- a/braindb/agent/prompts/system_prompt.md
+++ b/braindb/agent/prompts/system_prompt.md
@@ -54,12 +54,10 @@ fall back to flat SQL.
    and understanding: multi-query fuzzy + full-text + **keyword-embedding** +
    graph traversal + decay + ranking. Use first when you don't yet know which
    specific entity you want — "what do we know about X."
-2. **`view_tree(entity_id, max_depth=N)`** — default for **entity-driven**
-   neighbourhood exploration. When you already have an entity ID (from a
-   previous `recall_memory` result or known beforehand) and want to see what
-   surrounds it 1-N hops out, with relation types and edge scores. Beats
-   `search_sql` for any "what's around this entity" question — SQL can't show
-   the chain in one call.
+2. **`view_tree(<id>, max_depth=N)`** — reveals an entity's connections in
+   one call: relations + 1-N hop neighbours + edge scores. Especially useful
+   when you have an entity ID and want its graph context — often sharper
+   than another `recall_memory` about the same entity.
 3. **`delegate_to_subagent`** — for any multi-step investigation or
    disambiguation ("is this the same person/thing?", "find and resolve X").
    A fresh agent with the full toolset; returns a summary. Prefer this over

--- a/braindb/agent/prompts/system_prompt.md
+++ b/braindb/agent/prompts/system_prompt.md
@@ -50,24 +50,29 @@ CRITICAL — every assistant message MUST be a tool call; never plain prose. The
 BrainDB's value is the graph + embeddings + ranking. Use that power; do not
 fall back to flat SQL.
 
-1. **`recall_memory`** — the default for ALL recall, discovery, and
-   understanding: multi-query fuzzy + full-text + **keyword-embedding** +
-   graph traversal + decay + ranking. This is almost always the right first
-   call.
-2. **`delegate_to_subagent`** — for any multi-step investigation or
+1. **`recall_memory`** — default for ALL **query-driven** recall, discovery,
+   and understanding: multi-query fuzzy + full-text + **keyword-embedding** +
+   graph traversal + decay + ranking. Use first when you don't yet know which
+   specific entity you want — "what do we know about X."
+2. **`view_tree(entity_id, max_depth=N)`** — default for **entity-driven**
+   neighbourhood exploration. When you already have an entity ID (from a
+   previous `recall_memory` result or known beforehand) and want to see what
+   surrounds it 1-N hops out, with relation types and edge scores. Beats
+   `search_sql` for any "what's around this entity" question — SQL can't show
+   the chain in one call.
+3. **`delegate_to_subagent`** — for any multi-step investigation or
    disambiguation ("is this the same person/thing?", "find and resolve X").
    A fresh agent with the full toolset; returns a summary. Prefer this over
    doing a long crawl yourself.
-3. `view_tree` / `view_entity_relations` / `get_entity` / `list_entities` —
-   targeted structure lookups.
-4. **`search_sql` — exception only.** A blunt SELECT has no embeddings, no
-   graph, no ranking — it throws away everything BrainDB is good at. Use it
-   *only* for a specific structured/aggregate question the tools above cannot
-   express (counts, GROUP BY, activity-log joins). Never for recall,
-   discovery, similarity, or understanding.
+4. `view_entity_relations` / `get_entity` / `list_entities` — direct lookups
+   (single-hop relations, full body of one entity, listing by filter).
+5. **`search_sql` ⚠ exception only — aggregates only** (counts, GROUP BY,
+   activity-log joins, schema inspection). A blunt SELECT has no embeddings,
+   no graph, no ranking — it throws away everything BrainDB is good at.
+   Never for recall, discovery, similarity, or understanding.
 
 If you reach for `search_sql` to "find" or "understand" something, stop —
-that's a `recall_memory` or `delegate_to_subagent` job.
+that's a `recall_memory` or `view_tree` or `delegate_to_subagent` job.
 
 ## READING CONTENT — previews vs the full body
 

--- a/braindb/agent/prompts/system_prompt.md
+++ b/braindb/agent/prompts/system_prompt.md
@@ -26,7 +26,7 @@ CRITICAL — every assistant message MUST be a tool call; never plain prose. The
 - `delete_entity(entity_id)`
 
 **Relations:**
-- `create_relation(from_entity_id, to_entity_id, relation_type, relevance_score, description)`
+- `create_relation(from_entity_id, to_entity_id, relation_type, relevance_score, importance_score, description)`
 - `view_entity_relations(entity_id)`
 - `delete_relation(relation_id)`
 

--- a/braindb/agent/prompts/system_prompt.md
+++ b/braindb/agent/prompts/system_prompt.md
@@ -55,10 +55,12 @@ fall back to flat SQL.
    graph traversal + decay + ranking. Use first when you don't yet know which
    specific entity you want — "what do we know about X."
 2. **`view_tree(<id>, max_depth=N)`** — the efficient "explore around this
-   entity" tool. One call returns the entity's neighbours grouped by
-   relation type, plus their edge scores, 1-N hops out. When you have an
-   entity ID and want to know what's related to it, this is usually a
-   better next step than another `recall_memory` about the same entity.
+   entity" tool. Returns a nested JSON tree: root keyed by entity_type,
+   `children` arrays per node, 1-N hops out, keyword/retired-wiki noise
+   filtered, `_truncated` marker if more remain. When you have an entity
+   ID and want what's connected, this is usually a better next step than
+   another `recall_memory`. On hub entities (wikis), pass `max_depth=3`
+   to see narrative chains.
 3. **`delegate_to_subagent`** — for any multi-step investigation or
    disambiguation ("is this the same person/thing?", "find and resolve X").
    A fresh agent with the full toolset; returns a summary. Prefer this over

--- a/braindb/agent/prompts/system_prompt.md
+++ b/braindb/agent/prompts/system_prompt.md
@@ -54,10 +54,11 @@ fall back to flat SQL.
    and understanding: multi-query fuzzy + full-text + **keyword-embedding** +
    graph traversal + decay + ranking. Use first when you don't yet know which
    specific entity you want — "what do we know about X."
-2. **`view_tree(<id>, max_depth=N)`** — reveals an entity's connections in
-   one call: relations + 1-N hop neighbours + edge scores. Especially useful
-   when you have an entity ID and want its graph context — often sharper
-   than another `recall_memory` about the same entity.
+2. **`view_tree(<id>, max_depth=N)`** — the efficient "explore around this
+   entity" tool. One call returns the entity's neighbours grouped by
+   relation type, plus their edge scores, 1-N hops out. When you have an
+   entity ID and want to know what's related to it, this is usually a
+   better next step than another `recall_memory` about the same entity.
 3. **`delegate_to_subagent`** — for any multi-step investigation or
    disambiguation ("is this the same person/thing?", "find and resolve X").
    A fresh agent with the full toolset; returns a summary. Prefer this over

--- a/braindb/agent/tools.py
+++ b/braindb/agent/tools.py
@@ -112,10 +112,10 @@ async def recall_memory(
     queries: list[str],
     max_results: int = settings.recall_default_max_results,
 ) -> str:
-    """Search BrainDB memory with multiple natural language queries.
+    """⭐ Primary recall tool — use FIRST for ANY "what do we know about X" question.
+
     Runs fuzzy + fulltext + keyword embedding search, merges with geometric mean,
     traverses the graph up to 3 hops, applies temporal decay.
-    Use this as the primary recall tool.
 
     QUERY STRATEGY — IMPORTANT for high-recall on narrow subjects:
 
@@ -634,7 +634,9 @@ async def delete_relation(relation_id: str) -> str:
 @function_tool
 @_verbose("view_tree")
 async def view_tree(entity_id: str, max_depth: int = 2) -> str:
-    """View the graph of connections around an entity (incoming + outgoing).
+    """⭐ Use when you already have an entity ID and want its 1-N hop neighbourhood
+    with relation types and edge scores. Preferred over search_sql for any
+    "what's around this entity" question — SQL can't show the chain in one call.
 
     Args:
         entity_id: UUID of the root entity.
@@ -668,7 +670,10 @@ async def view_tree(entity_id: str, max_depth: int = 2) -> str:
 @function_tool
 @_verbose("search_sql")
 async def search_sql(query: str) -> str:
-    """Run a read-only SQL query (SELECT/WITH only). Use for complex exploration.
+    """⚠ Aggregates ONLY (counts, GROUP BY, joins for stats). NEVER for recall /
+    discovery / understanding — that's recall_memory. NEVER for "what's around
+    this entity" — that's view_tree. If you're using SQL to find or understand
+    something, stop and pick the right tool.
 
     Args:
         query: SQL query — must start with SELECT or WITH.

--- a/braindb/agent/tools.py
+++ b/braindb/agent/tools.py
@@ -542,7 +542,8 @@ async def create_relation(
     from_entity_id: str,
     to_entity_id: str,
     relation_type: str,
-    relevance_score: float = 0.7,
+    relevance_score: float = 0.5,
+    importance_score: float = 0.5,
     description: Optional[str] = None,
 ) -> str:
     """Create a relation between two entities.
@@ -551,7 +552,8 @@ async def create_relation(
         from_entity_id: Source entity UUID.
         to_entity_id: Target entity UUID.
         relation_type: One of: supports, contradicts, elaborates, refers_to, derived_from, similar_to, is_example_of, challenges, tagged_with.
-        relevance_score: 0-1 (default 0.7).
+        relevance_score: 0-1 — how tight the semantic link is (0.9 = strong, 0.5 = neutral / "didn't judge", 0.2 = weak).
+        importance_score: 0-1 — how much losing this edge would degrade recall (0.9 = critical, 0.5 = neutral / "didn't judge", 0.2 = trivial).
         description: Why this relation exists.
     """
     try:
@@ -559,9 +561,9 @@ async def create_relation(
             with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
                 try:
                     cur.execute(
-                        """INSERT INTO relations (from_entity_id, to_entity_id, relation_type, relevance_score, description)
-                           VALUES (%s, %s, %s, %s, %s) RETURNING id""",
-                        (from_entity_id, to_entity_id, relation_type, relevance_score, description),
+                        """INSERT INTO relations (from_entity_id, to_entity_id, relation_type, relevance_score, importance_score, description)
+                           VALUES (%s, %s, %s, %s, %s, %s) RETURNING id""",
+                        (from_entity_id, to_entity_id, relation_type, relevance_score, importance_score, description),
                     )
                     rid = cur.fetchone()["id"]
                 except psycopg2.errors.UniqueViolation:

--- a/braindb/agent/tools.py
+++ b/braindb/agent/tools.py
@@ -643,29 +643,76 @@ async def view_tree(entity_id: str, max_depth: int = 2) -> str:
         entity_id: UUID of the root entity.
         max_depth: How far to traverse (1-3, default 2).
     """
+    if max_depth < 1 or max_depth > 3:
+        return _err("max_depth must be 1-3")
     try:
         with get_conn() as conn:
             with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
                 cur.execute(
-                    """SELECT e.*, r.relation_type, r.relevance_score, r.description AS rel_desc,
-                              CASE WHEN r.from_entity_id = %s THEN 'out' ELSE 'in' END AS dir
-                       FROM relations r
-                       JOIN entities e ON e.id = CASE WHEN r.from_entity_id = %s THEN r.to_entity_id ELSE r.from_entity_id END
-                       WHERE r.from_entity_id = %s OR r.to_entity_id = %s""",
-                    (entity_id, entity_id, entity_id, entity_id),
+                    "SELECT id, entity_type, content FROM entities WHERE id = %s",
+                    (entity_id,),
+                )
+                root = cur.fetchone()
+                if not root:
+                    return _err(f"Entity not found: {entity_id}")
+                # Recursive bidirectional walk, respects max_depth.
+                cur.execute(
+                    """WITH RECURSIVE traversal AS (
+                        SELECT e.id, e.entity_type, e.content,
+                               0 AS depth, ARRAY[e.id] AS visited,
+                               NULL::TEXT AS via_rel,
+                               NULL::FLOAT AS edge_score,
+                               NULL::TEXT AS direction
+                        FROM entities e WHERE e.id = %s
+                        UNION ALL
+                        SELECT target.id, target.entity_type, target.content,
+                               t.depth + 1, t.visited || target.id,
+                               r.relation_type, r.relevance_score,
+                               CASE WHEN r.from_entity_id = t.id THEN 'out' ELSE 'in' END
+                        FROM traversal t
+                        JOIN relations r ON r.from_entity_id = t.id OR r.to_entity_id = t.id
+                        JOIN entities target ON target.id = CASE
+                            WHEN r.from_entity_id = t.id THEN r.to_entity_id
+                            ELSE r.from_entity_id END
+                        WHERE t.depth < %s AND NOT (target.id = ANY(t.visited))
+                    )
+                    SELECT DISTINCT ON (id) id, entity_type, content, depth,
+                           via_rel, edge_score, direction
+                    FROM traversal WHERE depth > 0
+                    ORDER BY id, depth, edge_score DESC NULLS LAST
+                    """,
+                    (entity_id, max_depth),
                 )
                 rows = [dict(r) for r in cur.fetchall()]
+        out = [f"ROOT [{root['entity_type']}] {_tree_label(root)} (id: {root['id']})"]
         if not rows:
-            return "No connections."
-        lines = [f"{len(rows)} connections from {entity_id}:"]
+            out.append("\n(no connections)")
+            return _truncate("\n".join(out))
+        rows.sort(key=lambda x: (x['depth'], -(x['edge_score'] or 0)))
+        last_depth = None
         for r in rows:
-            lines.append(
-                f"  [{r['dir']}] {r['relation_type']} (rel={r['relevance_score']})\n"
-                f"    [{r['entity_type']}] {r['content'][:80]} (id: {r['id']})"
+            if r['depth'] != last_depth:
+                same_depth_n = sum(1 for x in rows if x['depth'] == r['depth'])
+                out.append(f"\nDEPTH {r['depth']} ({same_depth_n}):")
+                last_depth = r['depth']
+            out.append(
+                f"  [{r['direction']}] {r['via_rel']} (rel={r['edge_score']})\n"
+                f"    [{r['entity_type']}] {_tree_label(r)} (id: {r['id']})"
             )
-        return _truncate("\n".join(lines))
+        return _truncate("\n".join(out))
     except Exception as e:
         return _err(str(e))
+
+
+def _tree_label(entity: dict) -> str:
+    """Short label for tree output. Wikis use canonical_name; others truncate content."""
+    import re as _r
+    content = (entity.get('content') or '').replace('\n', ' ')
+    if entity.get('entity_type') == 'wiki':
+        m = _r.search(r'canonical_name=([^\s]+)', content)
+        if m:
+            return m.group(1)
+    return content[:80]
 
 
 @function_tool

--- a/braindb/agent/tools.py
+++ b/braindb/agent/tools.py
@@ -646,58 +646,30 @@ async def view_tree(entity_id: str, max_depth: int = 2) -> str:
     if max_depth < 1 or max_depth > 3:
         return _err("max_depth must be 1-3")
     try:
+        from braindb.services.tree import build_entity_tree
         with get_conn() as conn:
-            with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
-                cur.execute(
-                    "SELECT id, entity_type, content FROM entities WHERE id = %s",
-                    (entity_id,),
-                )
-                root = cur.fetchone()
-                if not root:
-                    return _err(f"Entity not found: {entity_id}")
-                # Recursive bidirectional walk, respects max_depth.
-                cur.execute(
-                    """WITH RECURSIVE traversal AS (
-                        SELECT e.id, e.entity_type, e.content,
-                               0 AS depth, ARRAY[e.id] AS visited,
-                               NULL::TEXT AS via_rel,
-                               NULL::FLOAT AS edge_score,
-                               NULL::TEXT AS direction
-                        FROM entities e WHERE e.id = %s
-                        UNION ALL
-                        SELECT target.id, target.entity_type, target.content,
-                               t.depth + 1, t.visited || target.id,
-                               r.relation_type, r.relevance_score,
-                               CASE WHEN r.from_entity_id = t.id THEN 'out' ELSE 'in' END
-                        FROM traversal t
-                        JOIN relations r ON r.from_entity_id = t.id OR r.to_entity_id = t.id
-                        JOIN entities target ON target.id = CASE
-                            WHEN r.from_entity_id = t.id THEN r.to_entity_id
-                            ELSE r.from_entity_id END
-                        WHERE t.depth < %s AND NOT (target.id = ANY(t.visited))
-                    )
-                    SELECT DISTINCT ON (id) id, entity_type, content, depth,
-                           via_rel, edge_score, direction
-                    FROM traversal WHERE depth > 0
-                    ORDER BY id, depth, edge_score DESC NULLS LAST
-                    """,
-                    (entity_id, max_depth),
-                )
-                rows = [dict(r) for r in cur.fetchall()]
+            tree = build_entity_tree(conn, entity_id, max_depth)
+        if tree is None:
+            return _err(f"Entity not found: {entity_id}")
+        root = tree["root"]
+        conns = tree["connections"]
         out = [f"ROOT [{root['entity_type']}] {_tree_label(root)} (id: {root['id']})"]
-        if not rows:
+        if not conns:
             out.append("\n(no connections)")
             return _truncate("\n".join(out))
-        rows.sort(key=lambda x: (x['depth'], -(x['edge_score'] or 0)))
+        # Group output by depth
         last_depth = None
-        for r in rows:
-            if r['depth'] != last_depth:
-                same_depth_n = sum(1 for x in rows if x['depth'] == r['depth'])
-                out.append(f"\nDEPTH {r['depth']} ({same_depth_n}):")
-                last_depth = r['depth']
+        for c in conns:
+            d = c["depth"]
+            if d != last_depth:
+                same_n = sum(1 for x in conns if x["depth"] == d)
+                out.append(f"\nDEPTH {d} ({same_n}):")
+                last_depth = d
+            ent = c["entity"]
+            dir_short = "out" if c.get("direction") == "outgoing" else "in"
             out.append(
-                f"  [{r['direction']}] {r['via_rel']} (rel={r['edge_score']})\n"
-                f"    [{r['entity_type']}] {_tree_label(r)} (id: {r['id']})"
+                f"  [{dir_short}] {c['via_relation_type']} (rel={c['relevance']})\n"
+                f"    [{ent['entity_type']}] {_tree_label(ent)} (id: {ent['id']})"
             )
         return _truncate("\n".join(out))
     except Exception as e:

--- a/braindb/agent/tools.py
+++ b/braindb/agent/tools.py
@@ -634,9 +634,10 @@ async def delete_relation(relation_id: str) -> str:
 @function_tool
 @_verbose("view_tree")
 async def view_tree(entity_id: str, max_depth: int = 2) -> str:
-    """⭐ Use when you already have an entity ID and want its 1-N hop neighbourhood
-    with relation types and edge scores. Preferred over search_sql for any
-    "what's around this entity" question — SQL can't show the chain in one call.
+    """⭐ Reveals an entity's connections in one call: relations + 1-N hop
+    neighbours + edge scores. Especially useful when you have an entity ID
+    (from a previous result) and want its graph context — often a sharper
+    choice than another `recall_memory` about the same entity.
 
     Args:
         entity_id: UUID of the root entity.

--- a/braindb/agent/tools.py
+++ b/braindb/agent/tools.py
@@ -636,10 +636,13 @@ async def delete_relation(relation_id: str) -> str:
 @function_tool
 @_verbose("view_tree")
 async def view_tree(entity_id: str, max_depth: int = 2) -> str:
-    """⭐ Reveals an entity's connections in one call: relations + 1-N hop
-    neighbours + edge scores. Especially useful when you have an entity ID
-    (from a previous result) and want its graph context — often a sharper
-    choice than another `recall_memory` about the same entity.
+    """⭐ Reveals an entity's neighbourhood as a nested JSON tree:
+    root keyed by ``entity_type``, ``children`` arrays per node, multi-path
+    first-wins, keyword/retired-wiki noise filtered, ``_truncated`` marker
+    when more remain. Especially useful when you have an entity ID (from a
+    previous result) and want its graph context — often a sharper choice
+    than another `recall_memory` about the same entity. Pass `max_depth=3`
+    on hub entities (wikis with many connections) to see narrative chains.
 
     Args:
         entity_id: UUID of the root entity.
@@ -650,43 +653,12 @@ async def view_tree(entity_id: str, max_depth: int = 2) -> str:
     try:
         from braindb.services.tree import build_entity_tree
         with get_conn() as conn:
-            tree = build_entity_tree(conn, entity_id, max_depth)
+            tree = build_entity_tree(conn, entity_id, max_depth=max_depth)
         if tree is None:
             return _err(f"Entity not found: {entity_id}")
-        root = tree["root"]
-        conns = tree["connections"]
-        out = [f"ROOT [{root['entity_type']}] {_tree_label(root)} (id: {root['id']})"]
-        if not conns:
-            out.append("\n(no connections)")
-            return _truncate("\n".join(out))
-        # Group output by depth
-        last_depth = None
-        for c in conns:
-            d = c["depth"]
-            if d != last_depth:
-                same_n = sum(1 for x in conns if x["depth"] == d)
-                out.append(f"\nDEPTH {d} ({same_n}):")
-                last_depth = d
-            ent = c["entity"]
-            dir_short = "out" if c.get("direction") == "outgoing" else "in"
-            out.append(
-                f"  [{dir_short}] {c['via_relation_type']} (rel={c['relevance']})\n"
-                f"    [{ent['entity_type']}] {_tree_label(ent)} (id: {ent['id']})"
-            )
-        return _truncate("\n".join(out))
+        return _truncate(json.dumps(tree, indent=2, default=str, ensure_ascii=False))
     except Exception as e:
         return _err(str(e))
-
-
-def _tree_label(entity: dict) -> str:
-    """Short label for tree output. Wikis use canonical_name; others truncate content."""
-    import re as _r
-    content = (entity.get('content') or '').replace('\n', ' ')
-    if entity.get('entity_type') == 'wiki':
-        m = _r.search(r'canonical_name=([^\s]+)', content)
-        if m:
-            return m.group(1)
-    return content[:80]
 
 
 @function_tool

--- a/braindb/ingest_watcher.py
+++ b/braindb/ingest_watcher.py
@@ -46,7 +46,7 @@ CHUNK_WORDS = 600           # target chunk size (~4-5k token context per extract
 CHUNK_OVERLAP = 75          # words of overlap between adjacent chunks — catches facts that span a boundary
 
 INGEST_TIMEOUT = 60
-AGENT_TIMEOUT = 600          # NIM free tier is slow/flaky on gemma-4-31b; generous timeout gives retries room to succeed
+AGENT_TIMEOUT = int(os.getenv("AGENT_TIMEOUT", "1200"))   # env-overridable; matches wiki_scheduler pattern. Generous default for slow / deep-exploring LLM runs.
 UUID_RE = re.compile(r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}")
 
 logging.basicConfig(
@@ -157,13 +157,15 @@ def extract_facts_from_chunk(ds_id: str, title: str, idx: int, total: int, chunk
         f"numbers, events, named decisions. Ignore filler, opinion, and generic\n"
         f"statements. Aim for quality over quantity: typically 3-8 facts per chunk.\n\n"
         f"For EACH fact:\n"
-        f'  a) Call save_fact(content="<the fact in one sentence>", certainty=0.8,\n'
-        f'     source="document", keywords=[2-4 precise tags], importance=0.6,\n'
-        f'     notes="Extracted from {title} chunk {idx}/{total}"). Record the\n'
-        f"     returned fact id.\n"
+        f'  a) Call save_fact(content="<the fact in one sentence>",\n'
+        f'     source="document", keywords=[2-4 precise tags],\n'
+        f'     notes="Extracted from {title} chunk {idx}/{total}"). Judge\n'
+        f"     certainty and importance per the tool's docstring guidance.\n"
+        f"     Record the returned fact id.\n"
         f"  b) Call create_relation(from_entity_id=<fact_id>, "
         f'to_entity_id="{ds_id}", relation_type="derived_from",\n'
-        f'     relevance_score=0.9, description="Fact extracted from {title}").\n\n'
+        f'     description="Fact extracted from {title}"). Judge\n'
+        f"     relevance_score and importance_score per the tool's docstring.\n\n"
         f"Do NOT call get_entity. Do NOT call update_entity on the datasource.\n"
         f"Do NOT touch the datasource content — it is read-only.\n\n"
         f"When all facts in this chunk are processed, call final_answer with\n"
@@ -210,7 +212,8 @@ def central_review(ds_id: str, title: str, fact_ids: list[str]) -> None:
         f"   or is_example_of. Only create relations that are genuinely meaningful.\n"
         f"2. If the set as a whole suggests a broader observation or inference that\n"
         f"   none of the individual facts capture, call save_thought with that\n"
-        f"   thought (certainty=0.6-0.8, source='agent-inference') and then\n"
+        f"   thought (source='agent-inference'; judge certainty + importance per\n"
+        f"   the tool docstring) and then\n"
         f'   create_relation(thought_id, "{ds_id}", "elaborates").\n'
         f"3. Optionally run recall_memory with 1-2 queries derived from the facts\n"
         f"   to find related EXISTING entities in memory. If any are clearly\n"

--- a/braindb/routers/memory.py
+++ b/braindb/routers/memory.py
@@ -80,67 +80,17 @@ def get_rules():
 
 @router.get("/tree/{entity_id}")
 def entity_tree(entity_id: UUID, max_depth: int = Query(default=2, ge=1, le=3)):
-    """Return an entity and its graph connections organized by depth."""
+    """Return an entity and its graph connections organized by depth.
+
+    Uses the shared `build_entity_tree` service (also used by the agent's
+    `view_tree` tool) so HTTP callers and the agent see the same data.
+    """
+    from braindb.services.tree import build_entity_tree
     with get_conn() as conn:
-        # Fetch root entity
-        with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
-            cur.execute("SELECT * FROM entities WHERE id = %s", (str(entity_id),))
-            root_row = cur.fetchone()
-        if not root_row:
-            raise HTTPException(404, "Entity not found")
-        root_row = dict(root_row)
-
-        # Fetch root extension fields
-        root_ext = fetch_ext(conn, [root_row])
-        root_data = {
-            "id": root_row["id"], "entity_type": root_row["entity_type"],
-            "title": root_row.get("title"), "content": root_row["content"],
-            "keywords": root_row.get("keywords") or [],
-            "importance": root_row["importance"],
-            "notes": root_row.get("notes"),
-            "ext": root_ext.get(root_row["id"], {}),
-        }
-
-        # Find all connections via relations (both directions)
-        with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
-            cur.execute("""
-                SELECT e.*, r.relation_type, r.relevance_score, r.description AS rel_description,
-                       CASE WHEN r.from_entity_id = %s THEN 'outgoing' ELSE 'incoming' END AS direction
-                FROM relations r
-                JOIN entities e ON e.id = CASE
-                    WHEN r.from_entity_id = %s THEN r.to_entity_id
-                    ELSE r.from_entity_id
-                END
-                WHERE r.from_entity_id = %s OR r.to_entity_id = %s
-            """, (str(entity_id), str(entity_id), str(entity_id), str(entity_id)))
-            direct_rows = [dict(r) for r in cur.fetchall()]
-
-        conn_ext = fetch_ext(conn, direct_rows) if direct_rows else {}
-
-        connections = []
-        seen_ids = {entity_id}
-        for row in direct_rows:
-            eid = row["id"]
-            if eid in seen_ids:
-                continue
-            seen_ids.add(eid)
-            connections.append({
-                "entity": {
-                    "id": eid, "entity_type": row["entity_type"],
-                    "title": row.get("title"), "content": row["content"],
-                    "keywords": row.get("keywords") or [],
-                    "importance": row["importance"],
-                    "ext": conn_ext.get(eid, {}),
-                },
-                "depth": 1,
-                "relevance": row.get("relevance_score", 1.0),
-                "via_relation_type": row.get("relation_type"),
-                "via_description": row.get("rel_description"),
-                "direction": row.get("direction"),
-            })
-
-        connections.sort(key=lambda c: (-c["relevance"], c["depth"]))
-        return {"root": root_data, "connections": connections}
+        tree = build_entity_tree(conn, str(entity_id), max_depth)
+    if tree is None:
+        raise HTTPException(404, "Entity not found")
+    return tree
 
 
 @router.get("/log")

--- a/braindb/routers/memory.py
+++ b/braindb/routers/memory.py
@@ -79,15 +79,33 @@ def get_rules():
 
 
 @router.get("/tree/{entity_id}")
-def entity_tree(entity_id: UUID, max_depth: int = Query(default=2, ge=1, le=3)):
-    """Return an entity and its graph connections organized by depth.
+def entity_tree(
+    entity_id: UUID,
+    max_depth: int = Query(default=2, ge=1, le=3),
+    include_keywords: bool = Query(default=False),
+    top_k: int = Query(default=40, ge=1, le=500),
+    min_path_score: float = Query(default=0.0, ge=0.0, le=1.0),
+):
+    """Return an entity and its graph neighbourhood as a nested JSON tree.
 
-    Uses the shared `build_entity_tree` service (also used by the agent's
-    `view_tree` tool) so HTTP callers and the agent see the same data.
+    Round-2f shape: root keyed by ``entity_type``; ``children`` array of
+    typed nodes (each keyed by its own ``entity_type`` and labelled to
+    its type — wiki=title, fact/thought=content, source=filename, etc.);
+    multi-path first-wins by accumulated path score; ``tagged_with``
+    keyword edges skipped by default (root's ``keywords`` array is the
+    one-liner instead). Top-``top_k`` connections are kept; the rest are
+    summarised with a single ``_truncated`` marker.
     """
     from braindb.services.tree import build_entity_tree
     with get_conn() as conn:
-        tree = build_entity_tree(conn, str(entity_id), max_depth)
+        tree = build_entity_tree(
+            conn,
+            str(entity_id),
+            max_depth=max_depth,
+            include_keywords=include_keywords,
+            top_k=top_k,
+            min_path_score=min_path_score,
+        )
     if tree is None:
         raise HTTPException(404, "Entity not found")
     return tree

--- a/braindb/services/context.py
+++ b/braindb/services/context.py
@@ -397,7 +397,14 @@ def assemble_context(conn, req: ContextRequest) -> ContextResponse:
     items = []
     for row in all_rows:
         eid = row["id"]
-        score = seed_scores.get(eid, 0.3)
+        # Score = the entity's own similarity if it was a seed; otherwise inherit
+        # the score of the seed it descended from (carried by `seed_origin_id`
+        # through the graph CTE). This propagates the real similarity signal
+        # through depth-1+ hops instead of resetting to a literal fallback.
+        score = seed_scores.get(eid)
+        if score is None:
+            origin = row.get("seed_origin_id")
+            score = seed_scores.get(str(origin), 1.0) if origin else 1.0
         depth = row.get("min_depth", 0)
         relevance = row.get("relevance", 1.0)
         items.append(_to_item(row, score, depth, relevance, ext_map.get(eid, {})))

--- a/braindb/services/graph.py
+++ b/braindb/services/graph.py
@@ -34,6 +34,7 @@ WITH RECURSIVE traversal AS (
         (
             t.accumulated_relevance
             * r.relevance_score
+            * COALESCE(r.importance_score, 0.5)
             * CASE t.depth + 1
                 WHEN 1 THEN 1.0
                 WHEN 2 THEN 0.8
@@ -47,10 +48,7 @@ WITH RECURSIVE traversal AS (
         r.notes,
         t.seed_origin_id
     FROM traversal t
-    JOIN relations r ON (
-        r.from_entity_id = t.id
-        OR (r.is_bidirectional AND r.to_entity_id = t.id)
-    )
+    JOIN relations r ON r.from_entity_id = t.id OR r.to_entity_id = t.id
     JOIN entities target ON
         target.id = CASE
             WHEN r.from_entity_id = t.id THEN r.to_entity_id
@@ -61,6 +59,7 @@ WITH RECURSIVE traversal AS (
       AND (
             t.accumulated_relevance
             * r.relevance_score
+            * COALESCE(r.importance_score, 0.5)
             * CASE t.depth + 1 WHEN 1 THEN 1.0 WHEN 2 THEN 0.8 ELSE 0.6 END
           ) > %s
 )

--- a/braindb/services/graph.py
+++ b/braindb/services/graph.py
@@ -16,7 +16,11 @@ WITH RECURSIVE traversal AS (
         NULL::UUID          AS via_relation_id,
         NULL::TEXT          AS via_relation_type,
         NULL::TEXT          AS via_description,
-        NULL::TEXT          AS via_notes
+        NULL::TEXT          AS via_notes,
+        -- The seed each row descended from. For seeds, it's themselves;
+        -- for graph-discovered rows, it propagates through the recursion
+        -- so context.py can inherit the seed's similarity score.
+        e.id                AS seed_origin_id
     FROM entities e
     WHERE e.id = ANY(%s::uuid[])
 
@@ -32,15 +36,16 @@ WITH RECURSIVE traversal AS (
             * r.relevance_score
             * CASE t.depth + 1
                 WHEN 1 THEN 1.0
-                WHEN 2 THEN 0.6
-                ELSE        0.3
+                WHEN 2 THEN 0.8
+                ELSE        0.6
               END
         )::FLOAT,
         t.visited || target.id,
         r.id,
         r.relation_type,
         r.description,
-        r.notes
+        r.notes,
+        t.seed_origin_id
     FROM traversal t
     JOIN relations r ON (
         r.from_entity_id = t.id
@@ -56,7 +61,7 @@ WITH RECURSIVE traversal AS (
       AND (
             t.accumulated_relevance
             * r.relevance_score
-            * CASE t.depth + 1 WHEN 1 THEN 1.0 WHEN 2 THEN 0.6 ELSE 0.3 END
+            * CASE t.depth + 1 WHEN 1 THEN 1.0 WHEN 2 THEN 0.8 ELSE 0.6 END
           ) > %s
 )
 SELECT DISTINCT ON (id)
@@ -65,7 +70,8 @@ SELECT DISTINCT ON (id)
     created_at, updated_at, accessed_at, access_count, metadata,
     depth           AS min_depth,
     accumulated_relevance AS relevance,
-    via_relation_id, via_relation_type, via_description, via_notes
+    via_relation_id, via_relation_type, via_description, via_notes,
+    seed_origin_id
 FROM traversal
 ORDER BY id, depth, accumulated_relevance DESC
 """

--- a/braindb/services/tree.py
+++ b/braindb/services/tree.py
@@ -1,0 +1,115 @@
+"""Shared tree-build service.
+
+Single source of truth for "walk the relation graph outward from an entity".
+Used by both the HTTP endpoint (`/api/v1/memory/tree/<id>`) and the agent's
+`view_tree` tool. Walks bidirectionally and respects `max_depth`.
+"""
+from __future__ import annotations
+
+import psycopg2.extras
+
+from braindb.services.context import fetch_ext
+
+
+_TREE_SQL = """
+WITH RECURSIVE traversal AS (
+    SELECT e.id, e.entity_type, e.title, e.content, e.keywords,
+           e.importance, e.notes,
+           0 AS depth,
+           ARRAY[e.id] AS visited,
+           NULL::TEXT  AS via_relation_type,
+           NULL::TEXT  AS via_description,
+           NULL::FLOAT AS relevance_score,
+           NULL::TEXT  AS direction
+    FROM entities e
+    WHERE e.id = %s
+
+    UNION ALL
+
+    SELECT target.id, target.entity_type, target.title, target.content,
+           target.keywords, target.importance, target.notes,
+           t.depth + 1,
+           t.visited || target.id,
+           r.relation_type,
+           r.description,
+           r.relevance_score,
+           CASE WHEN r.from_entity_id = t.id THEN 'outgoing' ELSE 'incoming' END
+    FROM traversal t
+    JOIN relations r ON r.from_entity_id = t.id OR r.to_entity_id = t.id
+    JOIN entities target ON target.id = CASE
+        WHEN r.from_entity_id = t.id THEN r.to_entity_id
+        ELSE r.from_entity_id
+    END
+    WHERE t.depth < %s
+      AND NOT (target.id = ANY(t.visited))
+)
+SELECT DISTINCT ON (id)
+    id, entity_type, title, content, keywords, importance, notes,
+    depth, via_relation_type, via_description, relevance_score, direction
+FROM traversal
+WHERE depth > 0
+ORDER BY id, depth, relevance_score DESC NULLS LAST
+"""
+
+
+def build_entity_tree(conn, entity_id: str, max_depth: int = 2) -> dict | None:
+    """Walk the relation graph bidirectionally from `entity_id` up to
+    `max_depth` hops. Returns:
+
+        {"root": <entity_dict>, "connections": [<connection_dict>, ...]}
+
+    or ``None`` if the root entity is not found.
+
+    Each connection dict has keys:
+        entity, depth, relevance, via_relation_type, via_description, direction
+    where `direction` is "outgoing" or "incoming" relative to the root path.
+    """
+    eid = str(entity_id)
+    with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+        cur.execute("SELECT * FROM entities WHERE id = %s", (eid,))
+        root_row = cur.fetchone()
+        if not root_row:
+            return None
+        root_row = dict(root_row)
+
+        cur.execute(_TREE_SQL, (eid, max_depth))
+        rows = [dict(r) for r in cur.fetchall()]
+
+    # Extension fields for root + all connection entities (single batched call)
+    ext_map = fetch_ext(conn, [root_row] + rows)
+
+    root_data = {
+        "id": root_row["id"],
+        "entity_type": root_row["entity_type"],
+        "title": root_row.get("title"),
+        "content": root_row["content"],
+        "keywords": root_row.get("keywords") or [],
+        "importance": root_row["importance"],
+        "notes": root_row.get("notes"),
+        "ext": ext_map.get(root_row["id"], {}),
+    }
+
+    connections = []
+    for row in rows:
+        rid = row["id"]
+        connections.append({
+            "entity": {
+                "id": rid,
+                "entity_type": row["entity_type"],
+                "title": row.get("title"),
+                "content": row["content"],
+                "keywords": row.get("keywords") or [],
+                "importance": row["importance"],
+                "ext": ext_map.get(rid, {}),
+            },
+            "depth": row["depth"],
+            "relevance": row.get("relevance_score", 1.0) if row.get("relevance_score") is not None else 1.0,
+            "via_relation_type": row.get("via_relation_type"),
+            "via_description": row.get("via_description"),
+            "direction": row.get("direction"),
+        })
+
+    # Sort by depth asc, then relevance desc within depth
+    connections.sort(key=lambda c: (c["depth"], -c["relevance"]))
+
+    return {"root": root_data, "connections": connections}

--- a/braindb/services/tree.py
+++ b/braindb/services/tree.py
@@ -1,68 +1,126 @@
 """Shared tree-build service.
 
-Single source of truth for "walk the relation graph outward from an entity".
-Used by both the HTTP endpoint (`/api/v1/memory/tree/<id>`) and the agent's
-`view_tree` tool. Walks bidirectionally and respects `max_depth`.
+`build_entity_tree` walks the relation graph bidirectionally from a root
+entity and returns a nested JSON tree. The same function is used by the
+HTTP endpoint `/api/v1/memory/tree/<id>` and the agent's `view_tree`
+tool — one shape, no behaviour drift.
+
+Shape (root keyed by ``entity_type``):
+
+    {
+      "<entity_type>": "<label>",
+      "keywords": ["k1", "k2", ...],   # only when root.keywords exist
+      "children": [
+          {"fact": "...", "children": [...]},
+          {"wiki": "..."},
+          {"source": "..."},
+          {"_truncated": "<N> more — increase max_depth or filter"}
+      ]
+    }
+
+Rules:
+* Per-hop multiplier is the same formula as ``services/graph.py``:
+  ``relevance_score × COALESCE(importance_score, 0.5) × depth_penalty``.
+* Multi-path entities collapse to a single occurrence under the parent
+  whose path scored highest (first-wins by accumulated score).
+* ``tagged_with`` edges and ``keyword`` target entities are skipped by
+  default (root's ``keywords[]`` column is the one-liner instead).
+* Retired wikis (``wikis_ext.retired_at IS NOT NULL``) are skipped.
+* ``top_k`` caps the rendered connections; a single ``_truncated`` marker
+  is appended to root's ``children`` when anything was dropped.
 """
 from __future__ import annotations
 
 import psycopg2.extras
 
-from braindb.services.context import fetch_ext
-
 
 _TREE_SQL = """
 WITH RECURSIVE traversal AS (
     SELECT e.id, e.entity_type, e.title, e.content, e.keywords,
-           e.importance, e.notes,
+           e.importance,
            0 AS depth,
            ARRAY[e.id] AS visited,
-           NULL::TEXT  AS via_relation_type,
-           NULL::TEXT  AS via_description,
-           NULL::FLOAT AS relevance_score,
-           NULL::TEXT  AS direction
+           NULL::UUID  AS parent_id,
+           1.0::FLOAT  AS accumulated_score
     FROM entities e
     WHERE e.id = %s
 
     UNION ALL
 
     SELECT target.id, target.entity_type, target.title, target.content,
-           target.keywords, target.importance, target.notes,
+           target.keywords, target.importance,
            t.depth + 1,
            t.visited || target.id,
-           r.relation_type,
-           r.description,
-           r.relevance_score,
-           CASE WHEN r.from_entity_id = t.id THEN 'outgoing' ELSE 'incoming' END
+           t.id::UUID,
+           (
+               t.accumulated_score
+               * COALESCE(r.relevance_score, 0.5)
+               * COALESCE(r.importance_score, 0.5)
+               * CASE t.depth + 1
+                   WHEN 1 THEN 1.0
+                   WHEN 2 THEN 0.8
+                   ELSE        0.6
+                 END
+           )::FLOAT
     FROM traversal t
     JOIN relations r ON r.from_entity_id = t.id OR r.to_entity_id = t.id
     JOIN entities target ON target.id = CASE
         WHEN r.from_entity_id = t.id THEN r.to_entity_id
         ELSE r.from_entity_id
     END
+    LEFT JOIN wikis_ext target_wiki ON target_wiki.entity_id = target.id
     WHERE t.depth < %s
       AND NOT (target.id = ANY(t.visited))
+      AND (
+            %s::boolean
+            OR (r.relation_type <> 'tagged_with' AND target.entity_type <> 'keyword')
+          )
+      AND (target.entity_type <> 'wiki' OR target_wiki.retired_at IS NULL)
 )
 SELECT DISTINCT ON (id)
-    id, entity_type, title, content, keywords, importance, notes,
-    depth, via_relation_type, via_description, relevance_score, direction
+    id, entity_type, title, content, keywords, importance,
+    depth, parent_id, accumulated_score
 FROM traversal
 WHERE depth > 0
-ORDER BY id, depth, relevance_score DESC NULLS LAST
+  AND accumulated_score >= %s
+ORDER BY id, accumulated_score DESC
 """
 
 
-def build_entity_tree(conn, entity_id: str, max_depth: int = 2) -> dict | None:
-    """Walk the relation graph bidirectionally from `entity_id` up to
-    `max_depth` hops. Returns:
+def _node_label(entity: dict) -> str:
+    """Type-aware label for a node in the tree.
 
-        {"root": <entity_dict>, "connections": [<connection_dict>, ...]}
+    * wikis → ``title`` (canonical_name) when present, else short content
+    * facts / thoughts → up to ~50 words / ~300 chars of content
+    * sources / datasources → ``title`` if set, else short content
+    * anything else → first 80 chars of content
+    """
+    et = (entity.get("entity_type") or "").lower()
+    content = (entity.get("content") or "").replace("\n", " ").strip()
+    title = (entity.get("title") or "").strip() or None
 
-    or ``None`` if the root entity is not found.
+    if et == "wiki":
+        return title or content[:80]
+    if et in ("source", "datasource"):
+        return title or content[:120]
+    if et in ("fact", "thought"):
+        if len(content) <= 300:
+            return content
+        return content[:297].rstrip() + "..."
+    return title or content[:80]
 
-    Each connection dict has keys:
-        entity, depth, relevance, via_relation_type, via_description, direction
-    where `direction` is "outgoing" or "incoming" relative to the root path.
+
+def build_entity_tree(
+    conn,
+    entity_id: str,
+    max_depth: int = 2,
+    include_keywords: bool = False,
+    top_k: int = 40,
+    min_path_score: float = 0.0,
+) -> dict | None:
+    """Walk the graph bidirectionally from ``entity_id`` and return a
+    nested JSON tree. See module docstring for shape and rules.
+    Returns ``None`` if the root entity doesn't exist.
     """
     eid = str(entity_id)
     with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
@@ -72,44 +130,46 @@ def build_entity_tree(conn, entity_id: str, max_depth: int = 2) -> dict | None:
             return None
         root_row = dict(root_row)
 
-        cur.execute(_TREE_SQL, (eid, max_depth))
+        cur.execute(
+            _TREE_SQL,
+            (eid, max_depth, bool(include_keywords), float(min_path_score)),
+        )
         rows = [dict(r) for r in cur.fetchall()]
 
-    # Extension fields for root + all connection entities (single batched call)
-    ext_map = fetch_ext(conn, [root_row] + rows)
+    rows.sort(key=lambda r: -float(r["accumulated_score"]))
+    kept = rows[:top_k]
+    dropped = len(rows) - len(kept)
 
-    root_data = {
-        "id": root_row["id"],
-        "entity_type": root_row["entity_type"],
-        "title": root_row.get("title"),
-        "content": root_row["content"],
-        "keywords": root_row.get("keywords") or [],
-        "importance": root_row["importance"],
-        "notes": root_row.get("notes"),
-        "ext": ext_map.get(root_row["id"], {}),
-    }
+    children_by_parent: dict[str, list[dict]] = {}
+    for r in kept:
+        children_by_parent.setdefault(str(r["parent_id"]), []).append(r)
+    for siblings in children_by_parent.values():
+        siblings.sort(key=lambda r: -float(r["accumulated_score"]))
 
-    connections = []
-    for row in rows:
-        rid = row["id"]
-        connections.append({
-            "entity": {
-                "id": rid,
-                "entity_type": row["entity_type"],
-                "title": row.get("title"),
-                "content": row["content"],
-                "keywords": row.get("keywords") or [],
-                "importance": row["importance"],
-                "ext": ext_map.get(rid, {}),
-            },
-            "depth": row["depth"],
-            "relevance": row.get("relevance_score", 1.0) if row.get("relevance_score") is not None else 1.0,
-            "via_relation_type": row.get("via_relation_type"),
-            "via_description": row.get("via_description"),
-            "direction": row.get("direction"),
+    def _build_node(row: dict) -> dict:
+        et = row["entity_type"]
+        node: dict = {et: _node_label(row)}
+        cid = str(row["id"])
+        if cid in children_by_parent:
+            node["children"] = [_build_node(c) for c in children_by_parent[cid]]
+        return node
+
+    result: dict = {root_row["entity_type"]: _node_label(root_row)}
+    if root_row.get("keywords"):
+        result["keywords"] = list(root_row["keywords"])
+
+    root_children: list[dict] = []
+    if eid in children_by_parent:
+        root_children = [_build_node(c) for c in children_by_parent[eid]]
+    if dropped > 0:
+        root_children.append({
+            "_truncated": (
+                f"{dropped} more — increase max_depth, "
+                f"raise min_path_score, or narrow filter"
+            )
         })
 
-    # Sort by depth asc, then relevance desc within depth
-    connections.sort(key=lambda c: (c["depth"], -c["relevance"]))
+    if root_children:
+        result["children"] = root_children
 
-    return {"root": root_data, "connections": connections}
+    return result

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ dependencies = [
 dev = [
     "pytest==9.0.3",
     "pytest-timeout==2.4.0",
+    "pytest-asyncio==0.23.7",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "braindb"
-version = "0.2.0"
+version = "0.4.0"
 description = "Persistent memory for LLM agents — thoughts, facts, sources, and behavioral rules with fuzzy + semantic search, graph traversal, and an internal agent."
 readme = "README.md"
 license = "Apache-2.0"

--- a/skills/braindb-agent/SKILL.md
+++ b/skills/braindb-agent/SKILL.md
@@ -26,18 +26,30 @@ BrainDB has its own internal agent (LiteLLM with pluggable provider via `LLM_PRO
 
 ---
 
-## TOOL PRIORITY
+## TOOL PRIORITY (read this first)
 
-The agent already uses the sophisticated retrieval (keyword-mediated fuzzy +
-embedding + graph + ranking, with a two-level diversity quota) and can
-delegate to subagents. Phrase requests as goals ("find / recall / understand
-…", "delegate a deep investigation of …"). **Do not tell it to "run SQL"**
-for recall or understanding — raw SQL discards the graph and embeddings. If
-you're tempted to phrase a request as *"run a SQL query that finds…"* for
-*finding* or *understanding* something, stop — that's the sophisticated
-recall path's job. Ask in plain English. SQL is only ever for an explicit
-aggregate ("how many facts per source?"), which you can simply ask for in
-plain English anyway.
+The agent has a clear order of tools it should reach for. When you phrase a
+request, lean into the sophisticated tools — don't ask it to "run SQL" for
+anything to do with recall or understanding.
+
+1. **Query-driven recall** — *"what do we know about X?"* → the agent calls
+   `/memory/context` (keyword-mediated fuzzy + embedding + graph + ranking,
+   with diversity quotas). The default for ALL discovery and understanding.
+2. **Entity-driven neighbourhood** — *"what's connected to entity Y?"* (once
+   you have an ID from a previous recall) → the agent calls `/memory/tree/<id>`.
+   Returns the multi-hop neighbourhood with relation types and edge scores in
+   one call. Use this instead of SQL for "around this entity" questions.
+3. **Multi-step investigation** — *"investigate / disambiguate / resolve X"*
+   → the agent delegates to a subagent. Keeps the main context clean.
+4. **Direct lookups** — `view_entity_relations`, `get_entity`, `list_entities`
+   for narrow questions.
+5. **`search_sql` ⚠ exception only** — for explicit aggregates (counts,
+   GROUP BY, activity-log joins). Never for finding / understanding /
+   "what's related to" — those are jobs for the tools above.
+
+If you're tempted to phrase a request as *"run a SQL query that finds…"* for
+*finding* or *understanding* something, stop — that's the recall or tree
+path's job. Ask in plain English.
 
 **Wikis** are first-class memory entities curated by an internal maintainer +
 writer pipeline. The agent surfaces them through recall automatically when

--- a/skills/braindb-agent/SKILL.md
+++ b/skills/braindb-agent/SKILL.md
@@ -35,10 +35,10 @@ anything to do with recall or understanding.
 1. **Query-driven recall** — *"what do we know about X?"* → the agent calls
    `/memory/context` (keyword-mediated fuzzy + embedding + graph + ranking,
    with diversity quotas). The default for ALL discovery and understanding.
-2. **Entity-driven neighbourhood** — *"what's connected to entity Y?"* (once
-   you have an ID from a previous recall) → the agent calls `/memory/tree/<id>`.
-   Returns the multi-hop neighbourhood with relation types and edge scores in
-   one call. Use this instead of SQL for "around this entity" questions.
+2. **Entity-driven neighbourhood** — the agent's `/memory/tree/<id>` reveals
+   an entity's connections in one call (relations + 1-N hop neighbours + edge
+   scores). Especially useful when an entity ID is already in hand — often
+   sharper than another query about the same entity.
 3. **Multi-step investigation** — *"investigate / disambiguate / resolve X"*
    → the agent delegates to a subagent. Keeps the main context clean.
 4. **Direct lookups** — `view_entity_relations`, `get_entity`, `list_entities`

--- a/skills/braindb-agent/SKILL.md
+++ b/skills/braindb-agent/SKILL.md
@@ -35,10 +35,12 @@ anything to do with recall or understanding.
 1. **Query-driven recall** — *"what do we know about X?"* → the agent calls
    `/memory/context` (keyword-mediated fuzzy + embedding + graph + ranking,
    with diversity quotas). The default for ALL discovery and understanding.
-2. **Entity-driven neighbourhood** — the agent's `/memory/tree/<id>` reveals
-   an entity's connections in one call (relations + 1-N hop neighbours + edge
-   scores). Especially useful when an entity ID is already in hand — often
-   sharper than another query about the same entity.
+2. **Entity-driven neighbourhood** — the agent's `view_tree` returns a
+   nested JSON tree (root keyed by `entity_type`, `children` arrays per
+   node, 1-N hops out, keyword + retired-wiki noise filtered by default,
+   `_truncated` marker if more remain). Especially useful when an entity
+   ID is already in hand — often sharper than another query about the
+   same entity. On hub entities pass `max_depth=3` for narrative chains.
 3. **Multi-step investigation** — *"investigate / disambiguate / resolve X"*
    → the agent delegates to a subagent. Keeps the main context clean.
 4. **Direct lookups** — `view_entity_relations`, `get_entity`, `list_entities`

--- a/skills/braindb/SKILL.md
+++ b/skills/braindb/SKILL.md
@@ -97,12 +97,11 @@ to flat SQL.
    `tagged_with`). A two-level diversity quota (per-search-term +
    per-keyword halving) keeps results balanced. Then graph traversal + decay
    + ranking.
-2. **`GET /api/v1/memory/tree/<id>?max_depth=N`** — the default for
-   **entity-driven** neighbourhood exploration ("what's around entity Y?"
-   when you already have an ID from a previous recall). Returns the multi-hop
-   neighbourhood in ONE call, with relation types and edge scores. Beats
-   `/memory/sql` for any "what's connected to X" question — SQL can't show
-   the chain in a single call.
+2. **`GET /api/v1/memory/tree/<id>?max_depth=N`** — reveals an entity's
+   connections in one call: relations + 1-N hop neighbours + edge scores.
+   Especially useful when you have an entity ID (from a previous recall)
+   and want its graph context — often a sharper choice than another
+   `/memory/context` call about the same entity.
 3. **`POST /api/v1/agent/query` with "delegate to a subagent…"** — for
    multi-step investigation/disambiguation; the agent researches and returns
    a summary.

--- a/skills/braindb/SKILL.md
+++ b/skills/braindb/SKILL.md
@@ -98,10 +98,14 @@ to flat SQL.
    per-keyword halving) keeps results balanced. Then graph traversal + decay
    + ranking.
 2. **`GET /api/v1/memory/tree/<id>?max_depth=N`** — reveals an entity's
-   connections in one call: relations + 1-N hop neighbours + edge scores.
-   Especially useful when you have an entity ID (from a previous recall)
-   and want its graph context — often a sharper choice than another
-   `/memory/context` call about the same entity.
+   neighbourhood as a nested JSON tree: root keyed by `entity_type`,
+   `children` arrays per node, 1-N hops out, keyword + retired-wiki
+   noise filtered by default, `_truncated` marker as a last child if
+   more remain. Especially useful when you have an entity ID (from a
+   previous recall) and want its graph context — often a sharper choice
+   than another `/memory/context` call about the same entity. On hub
+   entities (wikis with many connections) pass `max_depth=3` to see
+   narrative chains.
 3. **`POST /api/v1/agent/query` with "delegate to a subagent…"** — for
    multi-step investigation/disambiguation; the agent researches and returns
    a summary.

--- a/skills/braindb/SKILL.md
+++ b/skills/braindb/SKILL.md
@@ -91,28 +91,38 @@ BrainDB's power is the graph + embeddings + ranking. Use it; do not fall back
 to flat SQL.
 
 1. **`POST /api/v1/memory/context`** (multi-query) — the default for ALL
-   recall, discovery, and understanding. BOTH the fuzzy and embedding
-   pathways are **keyword-mediated** (the query matches against keyword
-   entities, entities surface via `tagged_with`). A two-level diversity
-   quota (per-search-term + per-keyword halving) keeps results
-   balanced. Then graph traversal + decay + ranking.
-2. **`POST /api/v1/agent/query` with "delegate to a subagent…"** — for
-   multi-step investigation/disambiguation; the agent researches and returns a
-   summary.
-3. `GET /api/v1/entities…`, `GET /api/v1/memory/tree/<id>`,
-   `GET /api/v1/entities/<id>/relations` — targeted structure lookups.
-4. **Wikis** — first-class entity type, curated topic pages assembled by an
+   **query-driven** recall, discovery, and understanding ("what do we know
+   about X?"). BOTH the fuzzy and embedding pathways are **keyword-mediated**
+   (the query matches against keyword entities, entities surface via
+   `tagged_with`). A two-level diversity quota (per-search-term +
+   per-keyword halving) keeps results balanced. Then graph traversal + decay
+   + ranking.
+2. **`GET /api/v1/memory/tree/<id>?max_depth=N`** — the default for
+   **entity-driven** neighbourhood exploration ("what's around entity Y?"
+   when you already have an ID from a previous recall). Returns the multi-hop
+   neighbourhood in ONE call, with relation types and edge scores. Beats
+   `/memory/sql` for any "what's connected to X" question — SQL can't show
+   the chain in a single call.
+3. **`POST /api/v1/agent/query` with "delegate to a subagent…"** — for
+   multi-step investigation/disambiguation; the agent researches and returns
+   a summary.
+4. `GET /api/v1/entities…`, `GET /api/v1/entities/<id>/relations` — direct
+   lookups (list-by-filter, single-hop relations).
+5. **Wikis** — first-class entity type, curated topic pages assembled by an
    internal maintainer + writer pipeline from facts/thoughts tagged with the
    same keyword. To browse: `GET /api/v1/entities?entity_type=wiki`. Full body:
    `GET /api/v1/entities/<id>`. Wikis also surface naturally in `/memory/context`.
    Write paths are documented in the WIKIS section below.
-5. **`POST /api/v1/memory/sql` — exception only.** A flat SELECT has no
-   embeddings/graph/ranking. Use it solely for a specific structured/aggregate
-   question (counts, GROUP BY, activity-log joins) the above cannot express.
-   **Never** for recall, discovery, similarity, or understanding.
+6. **`POST /api/v1/memory/sql` ⚠ exception only — aggregates only.** A flat
+   SELECT has no embeddings/graph/ranking. Use it solely for a specific
+   structured/aggregate question (counts, GROUP BY, activity-log joins) the
+   above cannot express. **Never** for recall, discovery, similarity, or
+   understanding. **Never** for "what's around this entity" — that's
+   `/memory/tree`.
 
 If you're about to use `/memory/sql` to *find* or *understand* something,
-stop — that's a `/memory/context` (or delegated `/agent/query`) job.
+stop — that's a `/memory/context` or `/memory/tree` (or delegated
+`/agent/query`) job.
 
 ### Previews vs full body
 

--- a/tests/test_create_relation_persistence.py
+++ b/tests/test_create_relation_persistence.py
@@ -1,0 +1,57 @@
+"""
+Locks in the importance_score wiring on relations.
+
+For agent-created rows the column was NULL until this round; now both
+relevance_score and importance_score must persist whatever the caller
+sets, and a fresh GET must return the same values.
+"""
+import requests
+
+
+def test_relation_persists_both_scores(api, make_fact):
+    a = make_fact("Anchor entity A for persistence check.")
+    b = make_fact("Anchor entity B for persistence check.")
+
+    body = {
+        "from_entity_id": a["id"],
+        "to_entity_id": b["id"],
+        "relation_type": "supports",
+        "relevance_score": 0.82,
+        "importance_score": 0.71,
+        "description": "Persistence round-trip",
+    }
+    r = requests.post(f"{api}/api/v1/relations", json=body, timeout=30)
+    assert r.status_code == 201, f"create relation failed: {r.status_code} {r.text}"
+    rel = r.json()
+
+    # POST response carries both scores.
+    assert rel["relevance_score"] == 0.82
+    assert rel["importance_score"] == 0.71
+
+    # And a fresh GET reads them back identically — proves the column is
+    # actually written, not just echoed in the response.
+    r = requests.get(f"{api}/api/v1/relations/{rel['id']}", timeout=10)
+    assert r.status_code == 200
+    fresh = r.json()
+    assert fresh["relevance_score"] == 0.82
+    assert fresh["importance_score"] == 0.71
+
+
+def test_relation_importance_score_not_null_by_default(api, make_fact):
+    """If the caller omits importance_score, it falls back to the schema
+    default (0.5) — NOT NULL. This locks the schema/router contract."""
+    a = make_fact("A for default-import.")
+    b = make_fact("B for default-import.")
+
+    body = {
+        "from_entity_id": a["id"],
+        "to_entity_id": b["id"],
+        "relation_type": "supports",
+    }
+    r = requests.post(f"{api}/api/v1/relations", json=body, timeout=30)
+    assert r.status_code == 201
+    rel = r.json()
+
+    assert rel["importance_score"] is not None
+    # Default is the schema's neutral 0.5.
+    assert rel["importance_score"] == 0.5

--- a/tests/test_graph_scoring_uses_importance.py
+++ b/tests/test_graph_scoring_uses_importance.py
@@ -1,0 +1,63 @@
+"""
+Locks in that the recall graph CTE multiplies BOTH per-edge scores
+(relevance_score AND importance_score) into the per-hop accumulated
+relevance. Before this round, importance_score sat in the column
+unused; the LLM's judgment of edge importance didn't affect ranking.
+
+Test approach: drive `graph_expand` directly (the function the recall
+pipeline calls). This isolates the behavior we want to lock without
+the noise of full-text discovery fallback + diversity-quota filtering
+that /memory/context layers on top.
+"""
+import uuid
+
+import requests
+from braindb.db import get_conn
+from braindb.services.graph import graph_expand
+
+
+def test_importance_score_moves_per_hop_relevance(api, make_fact):
+    """Two relations from the same seed, identical relation_type and
+    relevance_score, ONLY differing in importance_score. The hop's
+    accumulated_relevance from graph_expand must reflect the difference."""
+    tag = uuid.uuid4().hex
+    seed = make_fact(f"Seed for {tag}", keywords=[tag])
+    hi_target = make_fact("Generic hi target.")
+    lo_target = make_fact("Generic lo target.")
+
+    for target_id, imp in ((hi_target["id"], 0.9), (lo_target["id"], 0.2)):
+        body = {
+            "from_entity_id": seed["id"],
+            "to_entity_id": target_id,
+            "relation_type": "elaborates",
+            "relevance_score": 0.7,
+            "importance_score": imp,
+            "description": "Test edge",
+        }
+        r = requests.post(f"{api}/api/v1/relations", json=body, timeout=30)
+        assert r.status_code == 201, r.text
+
+    with get_conn() as conn:
+        rows = graph_expand(conn, [seed["id"]], max_depth=1, min_relevance=0.01)
+
+    by_id = {str(r["id"]): r for r in rows}
+    assert hi_target["id"] in by_id, "hi_target not reached by graph_expand"
+    assert lo_target["id"] in by_id, "lo_target not reached by graph_expand"
+
+    hi_rel = by_id[hi_target["id"]]["relevance"]
+    lo_rel = by_id[lo_target["id"]]["relevance"]
+
+    # Both reached via the same one-hop path; only importance_score differs.
+    # With the fix in graph.py the per-hop multiplier multiplies by
+    # COALESCE(r.importance_score, 0.5), so hi (imp 0.9) > lo (imp 0.2).
+    # Per-hop math: 1.0 * 0.7 * imp * depth_penalty(1.0)
+    assert hi_rel > lo_rel, (
+        f"importance_score does not move per-hop relevance: "
+        f"hi={hi_rel:.4f} lo={lo_rel:.4f}"
+    )
+    # Sanity: ratio hi/lo ~= 0.9 / 0.2 = 4.5 (within rounding).
+    ratio = hi_rel / lo_rel
+    assert 4.0 < ratio < 5.0, (
+        f"per-hop relevance ratio should track importance_score ratio "
+        f"(0.9/0.2=4.5); got hi/lo={ratio:.3f}"
+    )

--- a/tests/test_graph_walks_both_directions.py
+++ b/tests/test_graph_walks_both_directions.py
@@ -1,0 +1,57 @@
+"""
+Locks in that the graph CTE walks relations in BOTH directions
+regardless of the `is_bidirectional` flag.
+
+Before this round, the CTE only walked `from -> to` unless
+`is_bidirectional=true` was set on the edge. That diverged from
+`services/tree.py` (which always walks both ways) and meant recall
+seeded from the `to_entity_id` could not reach the `from_entity_id`
+through a unidirectional edge — the bloat the user explicitly flagged.
+
+Test approach: drive `graph_expand` directly. Avoids the noise of the
+full recall pipeline's discovery fallback that complicates HTTP-based
+tests with arbitrary DB state.
+"""
+import uuid
+
+import requests
+from braindb.db import get_conn
+from braindb.services.graph import graph_expand
+
+
+def test_graph_expand_walks_unidirectional_edge_backwards(api, make_fact):
+    tag = uuid.uuid4().hex
+
+    # A is the "from" side. B is the "to" side and is the SEED.
+    # Edge: A -> B with is_bidirectional=false (default).
+    # graph_expand seeded from [B] must still reach A by walking the
+    # edge backwards.
+    a = make_fact(f"Anchor A for {tag}")
+    b = make_fact(f"Anchor B for {tag}", keywords=[tag])
+
+    body = {
+        "from_entity_id": a["id"],
+        "to_entity_id": b["id"],
+        "relation_type": "supports",
+        "relevance_score": 0.8,
+        "importance_score": 0.6,
+        "is_bidirectional": False,
+        "description": "Unidirectional A -> B for bidirectional-walk test",
+    }
+    r = requests.post(f"{api}/api/v1/relations", json=body, timeout=30)
+    assert r.status_code == 201, r.text
+
+    with get_conn() as conn:
+        rows = graph_expand(conn, [b["id"]], max_depth=1, min_relevance=0.05)
+
+    by_id = {str(r["id"]): r for r in rows}
+    assert b["id"] in by_id, "B (the seed) is missing from graph_expand result"
+    assert a["id"] in by_id, (
+        "A (the from-side of a unidirectional edge) was NOT reached by "
+        "graph_expand seeded from B. The CTE is not walking edges backwards."
+    )
+    a_row = by_id[a["id"]]
+    assert a_row["min_depth"] == 1, (
+        f"A should be reached at depth=1, got depth={a_row['min_depth']}"
+    )
+    assert a_row["via_relation_type"] == "supports"

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -11,6 +11,7 @@ in the automated suite. The behavior was manually verified during Phase A
 end-to-end ingestion: the Smart Sand article's 10,357-char content was
 preserved across three full runs of the watcher's chunked pipeline.
 """
+import uuid
 from pathlib import Path
 
 import requests
@@ -56,7 +57,8 @@ def _find_datasource_by_title(api: str, title: str) -> dict | None:
 
 def test_ingest_new_returns_201(api, created_entities):
     """First ingest of a fresh file returns 201."""
-    content = "A unique pytest ingest-test body. " * 10
+    # Unique per-run content so prior runs' rows in the DB can't dedup-fire on us.
+    content = f"A unique pytest ingest-test body {uuid.uuid4().hex}. " * 10
     _write_sample(content)
     try:
         r = requests.post(
@@ -80,7 +82,8 @@ def test_ingest_new_returns_201(api, created_entities):
 
 def test_ingest_duplicate_returns_200(api, created_entities):
     """Second ingest with the same bytes returns 200 (idempotent)."""
-    content = "Idempotency pytest body. " * 15
+    # Unique per-run content so prior runs' rows in the DB can't dedup-fire on us.
+    content = f"Idempotency pytest body {uuid.uuid4().hex}. " * 15
     _write_sample(content)
     try:
         # First call — 201
@@ -120,7 +123,8 @@ def test_ingest_dup_preserves_first_seen_metadata(api, created_entities):
     with new metadata). A second ingest with different keywords must not
     overwrite the first-seen keywords or swap the id.
     """
-    content = "Dup-metadata pytest body. " * 20
+    # Unique per-run content so prior runs' rows in the DB can't dedup-fire on us.
+    content = f"Dup-metadata pytest body {uuid.uuid4().hex}. " * 20
     _write_sample(content)
     try:
         r1 = requests.post(

--- a/tests/test_ingest_watcher_no_dictation.py
+++ b/tests/test_ingest_watcher_no_dictation.py
@@ -1,0 +1,55 @@
+"""
+Locks in that the watcher's prompts NO LONGER dictate parameter values
+to the LLM. Before this round, every fact extracted from every document
+got the same `certainty=0.8`, `importance=0.6`, `relevance_score=0.9`
+because the watcher's prompt copy-pasted those numbers into the
+example call the LLM was told to make. That hid the LLM's judgment.
+
+This is a static regex check on the prompt-builder source — no LLM
+call, no DB hit, deterministic. The live variance check is performed
+manually with a user-chosen file after deploy.
+"""
+from pathlib import Path
+
+import re
+
+
+WATCHER_PATH = Path(__file__).resolve().parents[1] / "braindb" / "ingest_watcher.py"
+
+
+def _watcher_source() -> str:
+    return WATCHER_PATH.read_text(encoding="utf-8")
+
+
+def test_chunk_extraction_prompt_does_not_dictate_certainty():
+    src = _watcher_source()
+    # Locate the chunk-extraction prompt block.
+    # The bug was a literal "certainty=0.8" embedded in the prompt string.
+    matches = re.findall(r'["\'][^"\']*certainty=0\.[0-9][^"\']*["\']', src)
+    assert not matches, (
+        "Watcher prompt still dictates a certainty literal to the LLM: "
+        f"{matches}. The LLM should judge certainty per save_fact / "
+        "save_thought docstring instead."
+    )
+
+
+def test_chunk_extraction_prompt_does_not_dictate_importance():
+    src = _watcher_source()
+    matches = re.findall(r'["\'][^"\']*importance=0\.[0-9][^"\']*["\']', src)
+    # Note: the watcher's datasource ingest body (importance=0.6) is fine
+    # — that's a Python dict literal, NOT inside a prompt string. The
+    # regex above looks specifically for the pattern inside a quoted
+    # prompt-text segment.
+    assert not matches, (
+        "Watcher prompt still dictates an importance literal to the LLM: "
+        f"{matches}. The LLM should judge importance per the tool docstring."
+    )
+
+
+def test_chunk_extraction_prompt_does_not_dictate_relevance_score():
+    src = _watcher_source()
+    matches = re.findall(r'["\'][^"\']*relevance_score=0\.[0-9][^"\']*["\']', src)
+    assert not matches, (
+        "Watcher prompt still dictates a relevance_score literal to the LLM: "
+        f"{matches}. The LLM should judge relevance_score per create_relation's docstring."
+    )


### PR DESCRIPTION
## v0.4.0 — per-edge LLM scoring + view_tree nested JSON

Headline: a focused pass on recall quality and the `view_tree` tool. The per-edge LLM judgment that was missing on `create_relation` is now wired through to graph scoring, and `view_tree` returns a nested JSON tree the agent can actually navigate (vs the depth-grouped text that silently clipped 70% of connections on popular wikis).

### Changed

- **`view_tree` / `GET /api/v1/memory/tree/<id>` — nested JSON shape.** Root keyed by `entity_type`, `children` arrays per node, multi-path first-wins by best accumulated path score, keyword + retired-wiki noise filtered by default, `_truncated` last-child marker when more remain. One shared builder (`build_entity_tree` in `braindb/services/tree.py`) for the HTTP endpoint and the agent tool. New optional query params: `include_keywords` (default `false`), `top_k` (default `40`), `min_path_score` (default `0.0`).
- **`create_relation` writes both edge scores.** The `importance_score` column had been NULL for every agent-created row since day one; the parameter is now on the tool, the watcher's extraction prompt no longer dictates literal score values (the LLM judges per docstring), and the graph CTE multiplies `relevance_score × COALESCE(importance_score, 0.5) × depth_penalty` per hop. `is_bidirectional` is now ignored by graph traversal — every edge walks both ways.
- **Seed-similarity propagation in graph scoring.** Recall hops carry the seed's similarity score forward through the graph; the depth multiplier is softened.
- **Prompts** refreshed across `system_prompt.md`, both skill files, `README.md`, and `BRAINDB_GUIDE.md` for the new tree shape.

### Fixed

- **`view_tree` keyword noise** through non-`tagged_with` edges.
- **`view_tree` duplicate retired-wiki siblings** — tree CTE now skips `wikis_ext.retired_at IS NOT NULL`.
- **Test isolation in `tests/test_ingest.py`** — content is uuid'd per run.
- **Missing test dep** — added `pytest-asyncio==0.23.7` to `[dev]`.

### Bench

- **Path A** (Claude Code + curl skill): 5/5 PASS, `view_tree` usage 0 → 1-2 calls (the structured shape is now usable in practice).
- **Path B** (Qwen 27B via `/agent/query`): 5/5 PASS, **−25% wall-clock**, **−26% tool calls**, **zero `delegate` calls** on the hardest question (was 2). Numbers in `benchmarks/runs/round-2f_comparison.md`.

### Upgrading from v0.3.0

No DB migration. No env-var changes. The wiki maintainer's existing retired-wiki pipeline now also gates `view_tree` traversal. `pyproject.toml` version field was at `0.2.0` in v0.3.0's tagged release (the bump was missed); this release catches it up to `0.4.0`.

### Test plan

- [x] 134/134 pytest pass (8 wiki_jobs_grouping host-only tests intentionally deselected when run via `docker exec`).
- [x] Path A bench 5/5 (pre-commit + post-commit + post-Micron-ingest).
- [x] Path B bench 5/5 (pre-commit + post-commit + post-Micron-ingest).
- [x] Live ingest of a 3100-word YouTube transcript: 29 facts extracted, 17 cross-fact relations, 1 synthesis thought, 1 wiki materialized end-to-end. Duplicate wiki created by maintainer race + auto-consolidated by the next maintainer tick — round-2f's retired-wiki filter exercised on real data.
- [x] Sensitive-content audit clean (no surname / no secrets / no internal paths / no email leaks across the 9-commit diff).
